### PR TITLE
Improve Shapely compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ pip install togo
 - Fast and efficient geometric operations
 - Support for standard geometry types: Point, Line, Ring, Polygon, and their multi-variants
 - Flexible API supporting both TG and Shapely conventions
-- Geometric predicates: contains, intersects, covers, touches, etc.
+- Geometric predicates: contains, intersects, covers, touches, etc. — accept any wrapper type directly (no manual `.as_geometry()` conversion needed)
 - Format conversion between WKT, GeoJSON, WKB, and HEX
 - Spatial indexing for accelerated queries
 - Memory-efficient C implementation with Python-friendly interface
 - Advanced operations via libgeos integration (buffer, unary union, simplify, centroid, convex_hull, etc.)
-- Distance and proximity operations (nearest_points, shortest_line)
+- Distance and proximity operations (nearest_points, shortest_line, project)
+- `MultiPolygon` and `MultiLineString` are real Python classes — `isinstance()` checks work correctly
+- Geometry equality via `==` operator consistent with Shapely semantics
 
 ## Basic Usage
 
@@ -61,6 +63,7 @@ from togo import Point, Polygon
 point = Point(1.0, 2.0)
 print(point.geom_type)     # 'Point'
 print(point.bounds)        # (1.0, 2.0, 1.0, 2.0)
+print(point.coords[0])     # (1.0, 2.0)  — indexable coordinate sequence
 
 poly = Polygon([(0, 0), (4, 0), (4, 4), (0, 4), (0, 0)])
 print(poly.area)           # 16.0
@@ -70,9 +73,20 @@ print(poly.length)         # 16.0
 print(point.to_wkt())      # 'POINT (1 2)'
 print(point.to_geojson())  # '{"type":"Point","coordinates":[1.0,2.0]}'
 
-# Spatial predicates
+# Spatial predicates — wrapper objects are accepted directly, no .as_geometry() needed
 if poly.contains(point):
     print("Polygon contains point!")
+
+if poly.intersects(Polygon([(3, 3), (5, 3), (5, 5), (3, 5), (3, 3)])):
+    print("Polygons intersect!")
+
+# Polygon.boundary — exterior ring as a LineString
+boundary = poly.boundary
+print(boundary.length)     # perimeter of polygon
+
+# Polygon.from_bounds — create a rectangle from a bounding box
+bbox = Polygon.from_bounds(0, 0, 10, 5)
+print(bbox.area)           # 50.0
 
 # Centroid (Shapely-compatible)
 centroid = poly.centroid  # Returns a Point geometry
@@ -230,24 +244,46 @@ print(f"Contains point (1.5,1.5): {geom.contains(Point(1.5,1.5).as_geometry())}"
 
 ### MultiGeometries
 
-Creating collections of geometries:
+`MultiPolygon` and `MultiLineString` are real Python classes, so `isinstance()` checks work correctly:
 
 ```python
-from togo import Geometry, Point, Line, Poly, Ring
+from togo import MultiPoint, MultiLineString, MultiPolygon, Poly, Ring, Geometry
 
-# Create a MultiPoint
-multi_point = Geometry.from_multipoint([(0,0), (1,1), Point(2,2)])
-
-# Create a MultiLineString
-multi_line = Geometry.from_multilinestring([
-    [(0,0), (1,1)],
-    Line([(2,2), (3,3)])
-])
-
-# Create a MultiPolygon
+# MultiPolygon — real class, supports isinstance
 poly1 = Poly(Ring([(0,0), (1,0), (1,1), (0,1), (0,0)]))
 poly2 = Poly(Ring([(2,2), (3,2), (3,3), (2,3), (2,2)]))
-multi_poly = Geometry.from_multipolygon([poly1, poly2])
+multi_poly = MultiPolygon([poly1, poly2])
+print(isinstance(multi_poly, MultiPolygon))  # True
+print(isinstance(multi_poly, Geometry))      # True
+
+# MultiLineString — real class, supports isinstance
+multi_line = MultiLineString([[(0,0), (1,1)], [(2,2), (3,3)]])
+print(isinstance(multi_line, MultiLineString))  # True
+
+# MultiPoint — factory (returns Geometry)
+multi_point = MultiPoint([(0,0), (1,1), (2,2)])
+
+# Low-level factory methods still available on Geometry
+multi_poly2 = Geometry.from_multipolygon([poly1, poly2])
+```
+
+### LineString.project()
+
+`project()` returns the distance along a line to the nearest projected point — equivalent to Shapely's `project()`:
+
+```python
+from togo import LineString, Point
+
+line = LineString([(0, 0), (10, 0)])
+
+# Distance to the start: 0.0
+print(line.project(Point(0, 0).as_geometry()))   # 0.0
+
+# Distance to the midpoint: 5.0
+print(line.project(Point(5, 0).as_geometry()))   # 5.0
+
+# Point above the midpoint still projects to 5.0
+print(line.project(Point(5, 3).as_geometry()))   # 5.0
 ```
 
 ## Polygon Indexing
@@ -267,20 +303,27 @@ Togo integrates with the [tgx](https://github.com/tidwall/tgx) extension and [li
 
 ### Example: Unary Union (GEOS integration)
 
-The `unary_union` method demonstrates this integration. It combines multiple geometries into a single geometry using GEOS's topological union, with all conversions handled automatically:
+`unary_union` is a module-level function (Shapely-compatible) that merges multiple geometries into one using GEOS topological union. It accepts any wrapper type directly — no `.as_geometry()` conversion required:
 
 ```python
-from togo import Geometry, Point, Poly, Ring
+from togo import Polygon, unary_union
 
-# Create several polygons
-poly1 = Poly(Ring([(0,0), (2,0), (2,2), (0,2), (0,0)]))
-poly2 = Poly(Ring([(1,1), (3,1), (3,3), (1,3), (1,1)]))
+# Create several polygons using the Shapely-compatible constructor
+poly1 = Polygon([(0,0), (2,0), (2,2), (0,2), (0,0)])
+poly2 = Polygon([(1,1), (3,1), (3,3), (1,3), (1,1)])
 
-# Perform unary union (requires tgx and libgeos)
-union = Geometry.unary_union([poly1, poly2])
+# Module-level unary_union — accepts Polygon wrapper objects directly
+union = unary_union([poly1, poly2])
 
-# The result is a single geometry representing the union of the input polygons
+# The result is a single geometry representing the union
+print(union.geom_type)   # 'Polygon'
 print(union.to_wkt())
+
+# Works with mixed types (Poly, Polygon, Geometry, etc.)
+from togo import Poly, Ring, Geometry
+poly3 = Poly(Ring([(5,0), (7,0), (7,2), (5,2), (5,0)]))
+union2 = unary_union([poly1, poly3])
+print(union2.geom_type)  # 'MultiPolygon' (non-overlapping)
 ```
 
 This operation uses `tgx` to convert `TG` geometries to `GEOS`, applies the union in `libgeos`, and converts the result back to `TG` format for further use in `ToGo`.

--- a/SHAPELY_API.md
+++ b/SHAPELY_API.md
@@ -33,11 +33,23 @@ ToGo provides the following Shapely-compatible class names:
 
 - `Point` - Create points
 - `LineString` - Create linestrings (alias for `Line`)
-- `Polygon` - Create polygons (alias for `Poly`)
-- `MultiPoint()` - Create multi-point geometries
-- `MultiLineString()` - Create multi-linestring geometries
-- `MultiPolygon()` - Create multi-polygon geometries
-- `GeometryCollection()` - Create geometry collections
+- `Polygon` - Create polygons (subclass of `Poly`)
+- `MultiPoint()` - Create multi-point geometries (returns `Geometry`)
+- `MultiLineString` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
+- `MultiPolygon` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
+- `GeometryCollection()` - Create geometry collections (returns `Geometry`)
+
+```python
+from togo import MultiPolygon, MultiLineString, Geometry, Poly, Ring
+
+poly1 = Poly(Ring([(0,0), (1,0), (1,1), (0,1), (0,0)]))
+mp = MultiPolygon([poly1])
+print(isinstance(mp, MultiPolygon))  # True
+print(isinstance(mp, Geometry))      # True
+
+mls = MultiLineString([[(0,0), (1,1)]])
+print(isinstance(mls, MultiLineString))  # True
+```
 
 ### Point
 
@@ -51,13 +63,19 @@ p = Point(1.5, 2.5)
 p.geom_type      # 'Point'
 p.x              # 1.5
 p.y              # 2.5
-p.coords         # [(1.5, 2.5)]
+p.coords         # [(1.5, 2.5)]  — indexable sequence
+p.coords[0]      # (1.5, 2.5)
+len(p.coords)    # 1
 p.bounds         # (1.5, 2.5, 1.5, 2.5)
 p.is_empty       # False
 p.is_valid       # True
 p.wkt            # 'POINT(1.5 2.5)'
 p.wkb            # bytes object
 p.__geo_interface__  # {'type': 'Point', 'coordinates': [1.5, 2.5]}
+
+# Equality
+Point(1.5, 2.5) == Point(1.5, 2.5)   # True
+Point(1.5, 2.5) == Point(0.0, 0.0)   # False
 ```
 
 ### LineString
@@ -70,7 +88,10 @@ line = LineString([(0, 0), (1, 1), (2, 2), (3, 3)])
 
 # Shapely-compatible properties
 line.geom_type   # 'LineString'
-line.coords      # [(0, 0), (1, 1), (2, 2), (3, 3)]
+line.coords      # [(0, 0), (1, 1), (2, 2), (3, 3)]  — indexable sequence
+line.coords[0]   # (0, 0)
+line.coords[-1]  # (3, 3)
+len(line.coords) # 4
 line.bounds      # (0, 0, 3, 3)
 line.is_empty    # False
 line.is_valid    # True
@@ -78,6 +99,13 @@ line.length      # 4.242... (property)
 line.wkt         # 'LINESTRING(0 0,1 1,2 2,3 3)'
 line.wkb         # bytes object
 line.__geo_interface__  # GeoJSON-like dict
+
+# project(point) — distance along line to nearest projected point (Shapely-compatible)
+from togo import Point
+line = LineString([(0, 0), (10, 0)])
+line.project(Point(5, 3).as_geometry())   # 5.0 — projects perpendicularly
+line.project(Point(0, 0).as_geometry())   # 0.0 — start of line
+line.project(Point(10, 0).as_geometry())  # 10.0 — end of line
 ```
 
 ### Polygon
@@ -100,11 +128,21 @@ poly.area        # 16.0
 poly.centroid    # Point geometry (center of mass)
 poly.is_empty    # False
 poly.is_valid    # True
-poly.exterior  # Ring object
+poly.exterior    # Ring object (exterior ring)
 poly.interiors   # List of Ring objects (holes)
+poly.boundary    # LineString — the exterior ring as a line
 poly.wkt         # 'POLYGON((0 0,4 0,4 4,0 4,0 0))'
 poly.wkb         # bytes object
 poly.__geo_interface__  # GeoJSON-like dict
+
+# intersects() — accepts wrapper objects directly (Shapely-compatible)
+other = Polygon([(3, 3), (5, 3), (5, 5), (3, 5), (3, 3)])
+poly.intersects(other)   # True (touching at corner)
+
+# from_bounds() — create a rectangle from a bounding box (Shapely-compatible)
+bbox = Polygon.from_bounds(0, 0, 10, 5)
+print(bbox.area)    # 50.0
+print(bbox.bounds)  # (0.0, 0.0, 10.0, 5.0)
 ```
 
 ## Module-Level Functions
@@ -143,6 +181,26 @@ geojson_str = to_geojson(poly)
 wkb_bytes = to_wkb(geom)
 ```
 
+### unary_union()
+
+`unary_union(geoms)` merges a sequence of geometries into a single geometry using GEOS (Shapely-compatible). Accepts any wrapper type directly — no `.as_geometry()` needed:
+
+```python
+from togo import Polygon, unary_union
+
+# Merge overlapping polygons
+poly1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+poly2 = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+union = unary_union([poly1, poly2])
+print(union.geom_type)  # 'Polygon'
+print(union.area)       # 7.0 (merged area)
+
+# Non-overlapping → MultiPolygon
+poly3 = Polygon([(10, 10), (11, 10), (11, 11), (10, 11), (10, 10)])
+union2 = unary_union([poly1, poly3])
+print(union2.geom_type)  # 'MultiPolygon'
+```
+
 ## Geometry Properties
 
 All geometry types support these Shapely-compatible properties:
@@ -166,45 +224,50 @@ geom.__geo_interface__  # Dict: GeoJSON-like interface
 # Point
 point.x           # x coordinate
 point.y           # y coordinate
-point.coords      # [(x, y)]
+point.coords      # [(x, y)] — indexable, len() works
+point.coords[0]   # (x, y)
 
 # LineString
-line.coords       # List of (x, y) tuples
+line.coords       # List of (x, y) tuples — indexable, len() works
+line.coords[0]    # first coordinate
+line.coords[-1]   # last coordinate
 line.length       # Float: length of line (property)
+line.project(pt)  # Float: distance along line to projected point
 
 # Polygon
 poly.area         # Float: area of polygon
-poly.exterior   # Ring: exterior ring
+poly.exterior     # Ring: exterior ring
 poly.interiors    # List[Ring]: list of holes
 poly.centroid     # Point: center of mass
+poly.boundary     # LineString: exterior ring as a line
 ```
 
 ## Spatial Predicates
 
-All predicates work with Shapely-compatible API:
+All predicates accept wrapper objects (`Point`, `LineString`, `Polygon`, etc.) **directly** — no manual `.as_geometry()` conversion is needed:
 
 ```python
-from togo import Point, Polygon, Ring, from_wkt
+from togo import Point, Polygon, from_wkt
 
 # Create geometries
 poly1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
 poly2 = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
 point = Point(0.5, 0.5)
 
-# Convert to Geometry for predicates
-geom1 = poly1.as_geometry()
-geom2 = poly2.as_geometry()
-pt_geom = point.as_geometry()
+# Predicates work directly on wrapper objects
+poly1.intersects(poly2)  # True  — Polygon.intersects() available
+poly1.intersects(point)  # True
 
-# Test predicates
-geom1.intersects(geom2)  # True
-geom1.contains(pt_geom)  # True
-geom1.equals(geom2)      # False
-geom1.disjoint(geom2)    # False
-geom1.touches(geom2)     # False
-geom1.within(geom2)      # False
-geom1.covers(pt_geom)    # True
-geom1.coveredby(geom2)   # False
+# Geometry-level predicates also accept wrappers directly
+geom1 = from_wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))")
+geom1.intersects(poly2)  # True  — no .as_geometry() needed
+geom1.contains(point)    # True
+geom1.equals(poly1)      # True
+geom1.disjoint(poly2)    # False
+geom1.touches(poly2)     # False
+geom1.within(poly2)      # False
+geom1.covers(point)      # True
+geom1.coveredby(poly2)   # False
 ```
 
 ## Geometric Operations
@@ -379,17 +442,20 @@ The `convex_hull` property:
 1. **Class names**: `Point`, `LineString`, `Polygon`
 2. **Properties**: `geom_type`, `bounds`, `area`, `coords`, `is_empty`, `is_valid`
 3. **Serialization**: `wkt`, `wkb`, `__geo_interface__`
-4. **Module functions**: `from_wkt()`, `from_geojson()`, `to_wkt()`
+4. **Module functions**: `from_wkt()`, `from_geojson()`, `to_wkt()`, `unary_union()`
+5. **Predicates**: `contains()`, `intersects()`, `touches()`, `within()`, `equals()`
+6. **Operations**: `intersection()`, `buffer()`, `simplify()`, `project()`
+7. **Multi-geometry classes**: `MultiPolygon`, `MultiLineString` are real Python classes, `isinstance()` works
+8. **Equality**: `geom1 == geom2` works consistently, geometries are hashable
 
-5. **Predicates**: `contains()`, `intersects()`, `touches()`, `crosses()`, `within()`, `equals()`
-6. **Operations**: `union()`, `intersection()`, `difference()`, `buffer()`, `simplify()`
 ### Differences
 
-1. **Geometry conversion**: ToGo uses `.as_geometry()` for predicates:
-   ```python
-   # ToGo
-   poly_geom = poly.as_geometry()
-   poly_geom.contains(point.as_geometry())
+1. **Low-level access**: ToGo exposes the TG object model (`Ring`, `Poly`, `Line`) which
+   Shapely does not have. Use `.as_geometry()` when you need to pass a wrapper object to
+   a function that specifically requires a `Geometry` instance.
+
+2. **GEOS dependency**: Buffer, simplify, centroid, convex_hull, intersection, unary_union,
+   nearest_points, shortest_line, and project all require the bundled `libgeos`.
 
 ## Performance
 
@@ -419,7 +485,7 @@ from togo import from_wkt, to_wkt
 ## Complete Example
 
 ```python
-from togo import Point, LineString, Polygon
+from togo import Point, LineString, Polygon, MultiPolygon, unary_union
 from togo import from_wkt, to_wkt
 
 # Create various geometries
@@ -428,25 +494,40 @@ line = LineString([(0, 0), (1, 1), (2, 2)])
 poly = Polygon([(0, 0), (5, 0), (5, 5), (0, 5), (0, 0)])
 
 # Check properties
-print(f"Point: {point.geom_type}, coords: {point.coords}")
+print(f"Point: {point.geom_type}, coords[0]: {point.coords[0]}")
 print(f"Line: length = {line.length:.2f}, bounds = {line.bounds}")
 print(f"Polygon: area = {poly.area}, bounds = {poly.bounds}")
 
-# Parse from WKT
-wkt = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 8 2, 8 8, 2 8, 2 2))"
-parsed = from_wkt(wkt)
-print(f"Parsed: {parsed.geom_type}")
+# project() — distance along line to projected point
+road = LineString([(0, 0), (100, 0)])
+stop = Point(40, 10)
+print(f"Stop is at {road.project(stop.as_geometry()):.1f}m along the road")  # 40.0m
 
-# Test spatial relationships
-pt_geom = point.as_geometry()
-poly_geom = poly.as_geometry()
+# Polygon.from_bounds() — create a bounding box rectangle
+bbox = Polygon.from_bounds(0, 0, 10, 5)
+print(f"BBox area: {bbox.area}")   # 50.0
 
-if poly_geom.contains(pt_geom):
-    print("Polygon contains the point!")
+# Polygon.boundary — exterior ring as a LineString
+print(f"Perimeter via boundary: {poly.boundary.length:.2f}")  # same as poly.length
 
-# Export to different formats
-print(f"WKT: {point.wkt}")
-print(f"GeoJSON: {point.__geo_interface__}")
+# Spatial predicates — no .as_geometry() needed
+other_poly = Polygon([(3, 3), (7, 3), (7, 7), (3, 7), (3, 3)])
+print(f"Intersects: {poly.intersects(other_poly)}")  # True
+print(f"Contains point: {from_wkt('POLYGON((0 0,5 0,5 5,0 5,0 0))').contains(point)}")  # True
+
+# unary_union — module-level Shapely-compatible function
+poly1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+poly2 = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+union = unary_union([poly1, poly2])
+print(f"Union type: {union.geom_type}, area: {union.area:.1f}")  # Polygon, 7.0
+
+# MultiPolygon — real class, isinstance works
+mp = MultiPolygon([poly1, Polygon([(10, 10), (11, 10), (11, 11), (10, 11), (10, 10)])])
+print(f"isinstance check: {isinstance(mp, MultiPolygon)}")  # True
+
+# Equality
+p1, p2 = Point(1, 2), Point(1, 2)
+print(f"p1 == p2: {p1 == p2}")  # True
 ```
 
 ## Nearest Points and Shortest Line (Shapely v2 API)
@@ -560,38 +641,59 @@ The `transform` function works with:
 
 ## API Reference Summary
 
-| Shapely API | ToGo API | Status |
-|-------------|----------|--------|
-| `Point(x, y)` | `Point(x, y)` | ✅ Supported |
-| `LineString(coords)` | `LineString(coords)` | ✅ Supported |
-| `Polygon(shell, holes)` | `Polygon(shell, holes=[...])` | ✅ Supported |
-| `geom.geom_type` | `geom.geom_type` | ✅ Supported |
-| `geom.bounds` | `geom.bounds` | ✅ Supported |
-| `geom.area` | `geom.area` | ✅ Supported |
-| `geom.length` | `geom.length` | ✅ Supported |
-| `geom.centroid` | `geom.centroid` | ✅ Supported (via GEOS) |
-| `geom.convex_hull` | `geom.convex_hull()` | ✅ Supported (via GEOS) |
-| `geom.is_empty` | `geom.is_empty` | ✅ Supported |
-| `geom.coords` | `geom.coords` | ✅ Supported |
-| `geom.wkt` | `geom.wkt` | ✅ Supported |
-| `geom.wkb` | `geom.wkb` | ✅ Supported |
-| `geom.__geo_interface__` | `geom.__geo_interface__` | ✅ Supported |
-| `from_wkt()` | `from_wkt()` | ✅ Supported |
-| `from_geojson()` | `from_geojson()` | ✅ Supported |
-| `to_wkt()` | `to_wkt()` | ✅ Supported |
-| `contains()` | `contains()` | ✅ Supported |
-| `intersects()` | `intersects()` | ✅ Supported |
-| `touches()` | `touches()` | ✅ Supported |
-| `within()` | `within()` | ✅ Supported |
-| `geom.buffer()` | `geom.buffer()` | ✅ Supported (via GEOS) |
-| `geom.simplify()` | `geom.simplify()` | ✅ Supported (via GEOS) |
-| `unary_union()` | `unary_union()` | ✅ Supported (via GEOS) |
-| `transform()` | `transform()` | ✅ Supported |
-| `nearest_points()` | `nearest_points()` | ✅ Supported (via GEOS) |
-| `shortest_line()` | `shortest_line()` | ✅ Supported (via GEOS, v2 API) |
-| `convex_hull()` | `convex_hull()` | ✅ Supported (via GEOS) |
-| `intersection()` | `intersection()` | ✅ Supported (via GEOS) |
+| Shapely API | ToGo API | Notes |
+|-------------|----------|-------|
+| `Point(x, y)` | `Point(x, y)` | ✅ |
+| `LineString(coords)` | `LineString(coords)` | ✅ |
+| `Polygon(shell, holes)` | `Polygon(shell, holes=[...])` | ✅ |
+| `Polygon.from_bounds(x1,y1,x2,y2)` | `Polygon.from_bounds(x1,y1,x2,y2)` | ✅ |
+| `MultiPolygon(polys)` | `MultiPolygon(polys)` | ✅ Real class; `isinstance` works |
+| `MultiLineString(lines)` | `MultiLineString(lines)` | ✅ Real class; `isinstance` works |
+| `geom.geom_type` | `geom.geom_type` | ✅ |
+| `geom.bounds` | `geom.bounds` | ✅ |
+| `geom.area` | `geom.area` | ✅ |
+| `geom.length` | `geom.length` | ✅ |
+| `geom.centroid` | `geom.centroid` | ✅ via GEOS |
+| `geom.convex_hull` | `geom.convex_hull` | ✅ via GEOS |
+| `geom.boundary` | `poly.boundary` | ✅ on Polygon/Poly |
+| `geom.is_empty` | `geom.is_empty` | ✅ |
+| `geom.is_valid` | `geom.is_valid` | ✅ via GEOS |
+| `geom.coords` | `geom.coords` | ✅ Indexable; `coords[i]` and `len()` work |
+| `geom.exterior` | `poly.exterior` | ✅ on Polygon/Poly |
+| `geom.interiors` | `poly.interiors` | ✅ on Polygon/Poly |
+| `geom.wkt` | `geom.wkt` | ✅ |
+| `geom.wkb` | `geom.wkb` | ✅ |
+| `geom.__geo_interface__` | `geom.__geo_interface__` | ✅ |
+| `geom1 == geom2` | `geom1 == geom2` | ✅ |
+| `from_wkt()` | `from_wkt()` | ✅ |
+| `from_geojson()` | `from_geojson()` | ✅ |
+| `to_wkt()` | `to_wkt()` | ✅ |
+| `geom.contains(other)` | `geom.contains(other)` | ✅ Accepts wrapper objects directly |
+| `geom.intersects(other)` | `geom.intersects(other)` | ✅ Accepts wrapper objects directly |
+| `poly.intersects(other)` | `poly.intersects(other)` | ✅ on Polygon/Poly |
+| `geom.touches(other)` | `geom.touches(other)` | ✅ Accepts wrapper objects directly |
+| `geom.within(other)` | `geom.within(other)` | ✅ Accepts wrapper objects directly |
+| `geom.equals(other)` | `geom.equals(other)` | ✅ Accepts wrapper objects directly |
+| `geom.buffer()` | `geom.buffer()` | ✅ via GEOS |
+| `geom.simplify()` | `geom.simplify()` | ✅ via GEOS |
+| `geom.intersection(other)` | `geom.intersection(other)` | ✅ via GEOS; accepts wrappers |
+| `line.project(point)` | `line.project(point)` | ✅ via GEOS |
+| `unary_union(geoms)` | `unary_union(geoms)` | ✅ Module-level; via GEOS |
+| `transform(fn, geom)` | `transform(fn, geom)` | ✅ |
+| `nearest_points(g1, g2)` | `nearest_points(g1, g2)` | ✅ via GEOS |
+| `shortest_line(g1, g2)` | `shortest_line(g1, g2)` | ✅ via GEOS |
+| `convex_hull(geom)` | `convex_hull(geom)` | ✅ via GEOS |
+| `intersection(g1, g2)` | `intersection(g1, g2)` | ✅ via GEOS |
 
 ## Conclusion
 
-ToGo now provides a Shapely-compatible API that makes it easy to use for developers familiar with Shapely, while leveraging the high performance of the underlying TG C library. The API is designed to be intuitive and follows Shapely conventions wherever possible.
+ToGo provides a comprehensive Shapely-compatible API that makes it easy to migrate from Shapely or use it as a drop-in replacement for common geometric operations. Key highlights:
+
+- **Wrapper objects are first-class citizens** — all spatial predicates and operations accept `Point`, `LineString`, `Polygon`, etc. directly without calling `.as_geometry()`.
+- **`MultiPolygon` and `MultiLineString` are real Python classes** — `isinstance()` checks work as expected.
+- **`unary_union(geoms)`** is a proper module-level function aligned with Shapely's API.
+- **New Polygon conveniences**: `from_bounds()`, `boundary`, `intersects()`.
+- **`LineString.project()`** for measuring distance-along-line projections.
+- **Geometry equality** via `==` and hashability are supported on all geometry types.
+
+All of this sits on top of the ultra-fast TG C library, with advanced operations powered by the bundled `libgeos`.

--- a/tests/test_shapely_api.py
+++ b/tests/test_shapely_api.py
@@ -831,6 +831,9 @@ class TestEdgeCases:
 
         multi = MultiLineString([])
         assert multi.geom_type == "MultiLineString"
+        multi_default = MultiLineString()
+        assert multi_default.geom_type == "MultiLineString"
+        assert "EMPTY" in repr(multi_default)
 
     def test_empty_multilinestring_no_args(self):
         from togo import MultiLineString
@@ -843,6 +846,9 @@ class TestEdgeCases:
 
         multi = MultiPolygon([])
         assert multi.geom_type == "MultiPolygon"
+        multi_default = MultiPolygon()
+        assert multi_default.geom_type == "MultiPolygon"
+        assert "EMPTY" in repr(multi_default)
 
     def test_empty_multipolygon_no_args(self):
         from togo import MultiPolygon

--- a/tests/test_shapely_api.py
+++ b/tests/test_shapely_api.py
@@ -832,10 +832,22 @@ class TestEdgeCases:
         multi = MultiLineString([])
         assert multi.geom_type == "MultiLineString"
 
+    def test_empty_multilinestring_no_args(self):
+        from togo import MultiLineString
+
+        multi = MultiLineString()
+        assert multi.geom_type == "MultiLineString"
+
     def test_empty_multipolygon(self):
         from togo import MultiPolygon
 
         multi = MultiPolygon([])
+        assert multi.geom_type == "MultiPolygon"
+
+    def test_empty_multipolygon_no_args(self):
+        from togo import MultiPolygon
+
+        multi = MultiPolygon()
         assert multi.geom_type == "MultiPolygon"
 
     def test_empty_geometrycollection(self):

--- a/tests/test_shapely_compat.py
+++ b/tests/test_shapely_compat.py
@@ -116,7 +116,7 @@ class TestLineStringProject:
         """project() accepts a Point wrapper object directly."""
         line = LineString([(0, 0), (10, 0)])
         pt = Point(4, 0)
-        dist = line.project(pt.as_geometry())
+        dist = line.project(pt)
         assert dist == pytest.approx(4.0, abs=1e-9)
 
     def test_project_returns_float(self):

--- a/tests/test_shapely_compat.py
+++ b/tests/test_shapely_compat.py
@@ -1,0 +1,481 @@
+"""Tests for Shapely compatibility required by model_based_planner.
+
+Covers:
+1. Module-level unary_union(geoms)
+2. LineString.project(point)
+3. Polygon.intersects(other)
+4. Polygon.boundary property
+5. Polygon.from_bounds(minx, miny, maxx, maxy)
+6. Point.coords and LineString.coords are indexable/sized sequences
+7. Operations/predicates accept wrapper geometry objects (Point/LineString/Polygon)
+8. MultiPolygon and MultiLineString are real Python classes
+9. Geometry equality behaves consistently
+"""
+
+import pytest
+
+import togo
+from togo import (
+    Geometry,
+    Line,
+    LineString,
+    MultiLineString,
+    MultiPolygon,
+    Point,
+    Poly,
+    Polygon,
+    Ring,
+    unary_union,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Module-level unary_union
+# ---------------------------------------------------------------------------
+
+
+class TestUnaryUnion:
+    def test_unary_union_two_polygons(self):
+        """unary_union on a list of two non-overlapping polygons returns a MultiPolygon."""
+        p1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        p2 = Polygon([(2, 0), (3, 0), (3, 1), (2, 1), (2, 0)])
+        result = unary_union([p1, p2])
+        assert result is not None
+        assert not result.is_empty
+
+    def test_unary_union_overlapping_polygons(self):
+        """unary_union merges overlapping polygons into a single Polygon."""
+        p1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+        p2 = Polygon([(1, 0), (3, 0), (3, 2), (1, 2), (1, 0)])
+        result = unary_union([p1, p2])
+        assert result.geom_type in ("Polygon", "MultiPolygon")
+        assert result.area > p1.area  # merged area should be larger
+
+    def test_unary_union_single_geometry(self):
+        """unary_union on single geometry returns equivalent geometry."""
+        p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        result = unary_union([p])
+        assert result.geom_type == "Polygon"
+
+    def test_unary_union_accepts_polygon_objects(self):
+        """unary_union accepts Polygon wrapper objects (not just Geometry)."""
+        polys = [
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]),
+            Polygon([(1, 0), (2, 0), (2, 1), (1, 1), (1, 0)]),
+        ]
+        result = unary_union(polys)
+        assert result is not None
+        assert not result.is_empty
+
+    def test_unary_union_empty_raises(self):
+        """unary_union on empty list raises ValueError."""
+        with pytest.raises(ValueError):
+            unary_union([])
+
+    def test_unary_union_is_module_level(self):
+        """unary_union is accessible at the togo module level."""
+        assert callable(togo.unary_union)
+
+
+# ---------------------------------------------------------------------------
+# 2. LineString.project(point)
+# ---------------------------------------------------------------------------
+
+
+class TestLineStringProject:
+    def test_project_start_point(self):
+        """Project point at start of line returns 0."""
+        line = LineString([(0, 0), (10, 0)])
+        pt = Point(0, 0)
+        dist = line.project(pt.as_geometry())
+        assert dist == pytest.approx(0.0, abs=1e-9)
+
+    def test_project_end_point(self):
+        """Project point at end of line returns length of line."""
+        line = LineString([(0, 0), (10, 0)])
+        pt = Point(10, 0)
+        dist = line.project(pt.as_geometry())
+        assert dist == pytest.approx(10.0, abs=1e-9)
+
+    def test_project_midpoint(self):
+        """Project midpoint returns half the line length."""
+        line = LineString([(0, 0), (10, 0)])
+        pt = Point(5, 0)
+        dist = line.project(pt.as_geometry())
+        assert dist == pytest.approx(5.0, abs=1e-9)
+
+    def test_project_perpendicular_point(self):
+        """Project point perpendicular to line returns correct distance."""
+        line = LineString([(0, 0), (10, 0)])
+        # Point is above the midpoint
+        pt = Point(5, 3)
+        dist = line.project(pt.as_geometry())
+        assert dist == pytest.approx(5.0, abs=1e-9)
+
+    def test_project_accepts_point_directly(self):
+        """project() accepts a Point wrapper object directly."""
+        line = LineString([(0, 0), (10, 0)])
+        pt = Point(4, 0)
+        dist = line.project(pt.as_geometry())
+        assert dist == pytest.approx(4.0, abs=1e-9)
+
+    def test_project_returns_float(self):
+        """project() returns a float."""
+        line = LineString([(0, 0), (10, 0)])
+        pt = Point(3, 0)
+        dist = line.project(pt.as_geometry())
+        assert isinstance(dist, float)
+
+
+# ---------------------------------------------------------------------------
+# 3. Polygon.intersects(other)
+# ---------------------------------------------------------------------------
+
+
+class TestPolygonIntersects:
+    def test_intersects_overlapping_polygons(self):
+        """Two overlapping polygons intersect."""
+        p1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+        p2 = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+        assert p1.intersects(p2) is True
+
+    def test_intersects_disjoint_polygons(self):
+        """Two disjoint polygons do not intersect."""
+        p1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        p2 = Polygon([(5, 5), (6, 5), (6, 6), (5, 6), (5, 5)])
+        assert p1.intersects(p2) is False
+
+    def test_intersects_with_geometry_object(self):
+        """Polygon.intersects() accepts Geometry objects."""
+        p1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+        p2 = Geometry("POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))", fmt="wkt")
+        assert p1.intersects(p2) is True
+
+    def test_intersects_with_polygon_wrapper(self):
+        """Polygon.intersects() accepts another Polygon wrapper directly."""
+        p1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+        p2 = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+        # Should work without manual as_geometry() conversion
+        assert p1.intersects(p2) is True
+
+    def test_intersects_touching_edge(self):
+        """Polygons sharing an edge intersect (touch)."""
+        p1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        p2 = Polygon([(1, 0), (2, 0), (2, 1), (1, 1), (1, 0)])
+        # Touching at edge - intersects returns True for touching geometries
+        assert p1.intersects(p2) is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Polygon.boundary property
+# ---------------------------------------------------------------------------
+
+
+class TestPolygonBoundary:
+    def test_boundary_is_linestring(self):
+        """Polygon.boundary returns a LineString (Line) object."""
+        p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        b = p.boundary
+        assert isinstance(b, Line)
+
+    def test_boundary_has_correct_coords(self):
+        """Polygon.boundary has the same coordinates as the exterior ring."""
+        coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]
+        p = Polygon(coords)
+        b = p.boundary
+        assert b.num_points == len(coords)
+
+    def test_boundary_matches_exterior(self):
+        """Polygon.boundary coordinates match the exterior ring."""
+        coords = [(0.0, 0.0), (2.0, 0.0), (2.0, 3.0), (0.0, 3.0), (0.0, 0.0)]
+        p = Polygon(coords)
+        b = p.boundary
+        b_coords = b.points(as_tuples=True)
+        assert b_coords[0] == (0.0, 0.0)
+        assert b_coords[1] == (2.0, 0.0)
+
+    def test_boundary_available_on_poly(self):
+        """Poly.boundary property also available on the base Poly class."""
+        ring = Ring([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        p = Poly(ring)
+        assert hasattr(p, "boundary")
+        b = p.boundary
+        assert isinstance(b, Line)
+
+
+# ---------------------------------------------------------------------------
+# 5. Polygon.from_bounds(minx, miny, maxx, maxy)
+# ---------------------------------------------------------------------------
+
+
+class TestPolygonFromBounds:
+    def test_from_bounds_returns_polygon(self):
+        """from_bounds returns a Polygon instance."""
+        p = Polygon.from_bounds(0, 0, 1, 1)
+        assert isinstance(p, Polygon)
+
+    def test_from_bounds_correct_bounds(self):
+        """from_bounds creates a polygon with correct bounds."""
+        minx, miny, maxx, maxy = 1.0, 2.0, 5.0, 7.0
+        p = Polygon.from_bounds(minx, miny, maxx, maxy)
+        bounds = p.bounds
+        assert bounds[0] == pytest.approx(minx)
+        assert bounds[1] == pytest.approx(miny)
+        assert bounds[2] == pytest.approx(maxx)
+        assert bounds[3] == pytest.approx(maxy)
+
+    def test_from_bounds_correct_area(self):
+        """from_bounds creates a polygon with correct area."""
+        p = Polygon.from_bounds(0, 0, 4, 3)
+        assert p.area == pytest.approx(12.0, rel=1e-6)
+
+    def test_from_bounds_is_rectangle(self):
+        """from_bounds creates a rectangular polygon (5 points including close)."""
+        p = Polygon.from_bounds(0, 0, 1, 1)
+        # Exterior ring should have 5 points (4 corners + closing point)
+        assert p.exterior.num_points == 5
+
+    def test_from_bounds_negative_coords(self):
+        """from_bounds works with negative coordinates."""
+        p = Polygon.from_bounds(-2, -3, 2, 3)
+        bounds = p.bounds
+        assert bounds[0] == pytest.approx(-2.0)
+        assert bounds[1] == pytest.approx(-3.0)
+        assert bounds[2] == pytest.approx(2.0)
+        assert bounds[3] == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# 6. Point.coords and LineString.coords indexable/sized
+# ---------------------------------------------------------------------------
+
+
+class TestCoordsIndexable:
+    def test_point_coords_index_zero(self):
+        """Point.coords[0] returns the (x, y) tuple."""
+        p = Point(3.0, 4.0)
+        assert p.coords[0] == (3.0, 4.0)
+
+    def test_point_coords_len(self):
+        """len(Point.coords) returns 1."""
+        p = Point(1.0, 2.0)
+        assert len(p.coords) == 1
+
+    def test_point_coords_iterable(self):
+        """Point.coords can be iterated."""
+        p = Point(5.0, 6.0)
+        coords_list = list(p.coords)
+        assert coords_list == [(5.0, 6.0)]
+
+    def test_linestring_coords_index_zero(self):
+        """LineString.coords[0] returns the first coordinate."""
+        line = LineString([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+        assert line.coords[0] == (1.0, 2.0)
+
+    def test_linestring_coords_index_last(self):
+        """LineString.coords[-1] returns the last coordinate."""
+        line = LineString([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+        assert line.coords[-1] == (5.0, 6.0)
+
+    def test_linestring_coords_len(self):
+        """len(LineString.coords) returns the correct number of points."""
+        line = LineString([(0, 0), (1, 0), (2, 0)])
+        assert len(line.coords) == 3
+
+    def test_linestring_coords_indexing(self):
+        """LineString.coords supports arbitrary indexing."""
+        pts = [(float(i), 0.0) for i in range(5)]
+        line = LineString(pts)
+        assert line.coords[2] == (2.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# 7. Operations/predicates accept wrapper objects without as_geometry()
+# ---------------------------------------------------------------------------
+
+
+class TestPredicatesAcceptWrappers:
+    def test_geometry_intersects_polygon_wrapper(self):
+        """Geometry.intersects() accepts a Polygon wrapper directly."""
+        g = Geometry("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", fmt="wkt")
+        p = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+        assert g.intersects(p) is True
+
+    def test_geometry_contains_point_wrapper(self):
+        """Geometry.contains() accepts a Point wrapper directly."""
+        g = Geometry("POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))", fmt="wkt")
+        pt = Point(2, 2)
+        assert g.contains(pt) is True
+
+    def test_geometry_within_polygon_wrapper(self):
+        """Geometry.within() accepts a Polygon wrapper directly."""
+        pt_geom = Geometry("POINT(2 2)", fmt="wkt")
+        p = Polygon([(0, 0), (4, 0), (4, 4), (0, 4), (0, 0)])
+        assert pt_geom.within(p) is True
+
+    def test_geometry_touches_polygon_wrapper(self):
+        """Geometry.touches() accepts a Polygon wrapper."""
+        g = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", fmt="wkt")
+        p = Polygon([(1, 0), (2, 0), (2, 1), (1, 1), (1, 0)])
+        # They touch at x=1
+        assert g.touches(p) is True
+
+    def test_geometry_disjoint_polygon_wrapper(self):
+        """Geometry.disjoint() accepts a Polygon wrapper."""
+        g = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", fmt="wkt")
+        p = Polygon([(5, 5), (6, 5), (6, 6), (5, 6), (5, 5)])
+        assert g.disjoint(p) is True
+
+    def test_geometry_equals_polygon_wrapper(self):
+        """Geometry.equals() accepts a Polygon wrapper."""
+        coords = [(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]
+        g = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", fmt="wkt")
+        p = Polygon(coords)
+        assert g.equals(p) is True
+
+    def test_geometry_intersection_polygon_wrapper(self):
+        """Geometry.intersection() accepts a Polygon wrapper directly."""
+        g = Geometry("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", fmt="wkt")
+        p = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+        result = g.intersection(p)
+        assert result.geom_type == "Polygon"
+        assert result.area == pytest.approx(1.0, rel=1e-6)
+
+    def test_polygon_intersects_no_manual_conversion(self):
+        """Polygon.intersects() works on another Polygon without as_geometry()."""
+        p1 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+        p2 = Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)])
+        # This must work without any manual as_geometry() call
+        result = p1.intersects(p2)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 8. MultiPolygon and MultiLineString are real Python classes
+# ---------------------------------------------------------------------------
+
+
+class TestMultiGeometryClasses:
+    def test_multipolygon_is_class(self):
+        """MultiPolygon is a real Python class (not a function)."""
+        assert isinstance(MultiPolygon, type)
+
+    def test_multilinestring_is_class(self):
+        """MultiLineString is a real Python class (not a function)."""
+        assert isinstance(MultiLineString, type)
+
+    def test_multipolygon_isinstance(self):
+        """isinstance(obj, MultiPolygon) works for MultiPolygon instances."""
+        polys = [
+            Poly(Ring([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])),
+            Poly(Ring([(2, 0), (3, 0), (3, 1), (2, 1), (2, 0)])),
+        ]
+        mp = MultiPolygon(polys)
+        assert isinstance(mp, MultiPolygon)
+
+    def test_multilinestring_isinstance(self):
+        """isinstance(obj, MultiLineString) works for MultiLineString instances."""
+        lines = [[(0, 0), (1, 1)], [(2, 2), (3, 3)]]
+        mls = MultiLineString(lines)
+        assert isinstance(mls, MultiLineString)
+
+    def test_multipolygon_isinstance_geometry(self):
+        """MultiPolygon instance is also an instance of Geometry."""
+        polys = [Poly(Ring([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]))]
+        mp = MultiPolygon(polys)
+        assert isinstance(mp, Geometry)
+
+    def test_multilinestring_isinstance_geometry(self):
+        """MultiLineString instance is also an instance of Geometry."""
+        lines = [[(0, 0), (1, 1)]]
+        mls = MultiLineString(lines)
+        assert isinstance(mls, Geometry)
+
+    def test_multipolygon_geom_type(self):
+        """MultiPolygon instance has geom_type 'MultiPolygon'."""
+        polys = [
+            Poly(Ring([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])),
+        ]
+        mp = MultiPolygon(polys)
+        assert mp.geom_type == "MultiPolygon"
+
+    def test_multilinestring_geom_type(self):
+        """MultiLineString instance has geom_type 'MultiLineString'."""
+        mls = MultiLineString([[(0, 0), (1, 1)]])
+        assert mls.geom_type == "MultiLineString"
+
+    def test_multipolygon_not_isinstance_multilinestring(self):
+        """MultiPolygon instance is NOT an instance of MultiLineString."""
+        polys = [Poly(Ring([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]))]
+        mp = MultiPolygon(polys)
+        assert not isinstance(mp, MultiLineString)
+
+    def test_multipolygon_from_polygons(self):
+        """MultiPolygon can be created from Polygon wrapper objects."""
+        polys = [
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]),
+            Polygon([(2, 0), (3, 0), (3, 1), (2, 1), (2, 0)]),
+        ]
+        mp = MultiPolygon(polys)
+        assert isinstance(mp, MultiPolygon)
+        assert mp.geom_type == "MultiPolygon"
+
+
+# ---------------------------------------------------------------------------
+# 9. Geometry equality consistency
+# ---------------------------------------------------------------------------
+
+
+class TestGeometryEquality:
+    def test_geometry_eq_same(self):
+        """Two identical geometries are equal via ==."""
+        g1 = Geometry("POINT(1 2)", fmt="wkt")
+        g2 = Geometry("POINT(1 2)", fmt="wkt")
+        assert g1 == g2
+
+    def test_geometry_eq_different(self):
+        """Two different geometries are not equal via ==."""
+        g1 = Geometry("POINT(1 2)", fmt="wkt")
+        g2 = Geometry("POINT(3 4)", fmt="wkt")
+        assert g1 != g2
+
+    def test_geometry_eq_polygon_wrapper(self):
+        """Geometry equals Polygon wrapper with same coordinates."""
+        g = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", fmt="wkt")
+        p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        assert g == p
+
+    def test_point_eq_point(self):
+        """Two Points with identical coords are equal."""
+        p1 = Point(1.0, 2.0)
+        p2 = Point(1.0, 2.0)
+        assert p1 == p2
+
+    def test_point_neq_different_coords(self):
+        """Two Points with different coords are not equal."""
+        p1 = Point(1.0, 2.0)
+        p2 = Point(3.0, 4.0)
+        assert p1 != p2
+
+    def test_point_eq_none(self):
+        """Point != None."""
+        p = Point(1.0, 2.0)
+        assert p != None  # noqa: E711
+
+    def test_geometry_eq_none(self):
+        """Geometry != None."""
+        g = Geometry("POINT(1 2)", fmt="wkt")
+        assert g != None  # noqa: E711
+
+    def test_point_hashable(self):
+        """Points can be used as dict keys (are hashable)."""
+        p = Point(1.0, 2.0)
+        d = {p: "test"}
+        assert d[p] == "test"
+
+    def test_geometry_hashable(self):
+        """Geometry objects can be used in sets."""
+        g1 = Geometry("POINT(1 2)", fmt="wkt")
+        g2 = Geometry("POINT(1 2)", fmt="wkt")
+        s = {g1, g2}
+        assert len(s) == 1  # same geometry, should deduplicate

--- a/tests/test_shapely_compat.py
+++ b/tests/test_shapely_compat.py
@@ -420,6 +420,16 @@ class TestMultiGeometryClasses:
         assert isinstance(mp, MultiPolygon)
         assert mp.geom_type == "MultiPolygon"
 
+    def test_multipolygon_no_args_is_empty(self):
+        """No-arg MultiPolygon initializes to an empty geometry."""
+        mp = MultiPolygon()
+        assert mp.geom_type == "MultiPolygon"
+
+    def test_multilinestring_no_args_is_empty(self):
+        """No-arg MultiLineString initializes to an empty geometry."""
+        mls = MultiLineString()
+        assert mls.geom_type == "MultiLineString"
+
 
 # ---------------------------------------------------------------------------
 # 9. Geometry equality consistency

--- a/togo.pyx
+++ b/togo.pyx
@@ -3181,13 +3181,17 @@ class MultiPolygon(Geometry):
         if polys is None:
             tmp = Geometry.from_multipolygon([])
         else:
-            # Convert Polygon objects to Poly for from_multipolygon
+            # Convert Polygon objects / coordinate sequences to Poly for from_multipolygon
             converted = []
             for p in polys:
                 if isinstance(p, Poly):
                     converted.append(p)
                 else:
-                    converted.append(Polygon(p[0], p[1] if len(p) > 1 else None))
+                    # Accept either (shell, holes) or a shell coordinate sequence
+                    if len(p) > 0 and isinstance(p[0], (tuple, list)) and len(p[0]) == 2:
+                        converted.append(Polygon(p))
+                    else:
+                        converted.append(Polygon(p[0], p[1] if len(p) > 1 else None))
             tmp = Geometry.from_multipolygon(converted)
         self._init_from_geometry(tmp)
 

--- a/togo.pyx
+++ b/togo.pyx
@@ -3175,7 +3175,9 @@ class MultiPolygon(Geometry):
         return Geometry.__new__(cls)
 
     def __init__(self, polys=None):
-        if polys is not None:
+        if polys is None:
+            tmp = Geometry.from_multipolygon([])
+        else:
             # Convert Polygon objects to Poly for from_multipolygon
             converted = []
             for p in polys:
@@ -3184,7 +3186,7 @@ class MultiPolygon(Geometry):
                 else:
                     converted.append(Polygon(p[0], p[1] if len(p) > 1 else None))
             tmp = Geometry.from_multipolygon(converted)
-            self._init_from_geometry(tmp)
+        self._init_from_geometry(tmp)
 
     def __repr__(self):
         return f"MultiPolygon({self.to_wkt()})"
@@ -3200,9 +3202,11 @@ class MultiLineString(Geometry):
         return Geometry.__new__(cls)
 
     def __init__(self, lines=None):
-        if lines is not None:
+        if lines is None:
+            tmp = Geometry.from_multilinestring([])
+        else:
             tmp = Geometry.from_multilinestring(lines)
-            self._init_from_geometry(tmp)
+        self._init_from_geometry(tmp)
 
     def __repr__(self):
         return f"MultiLineString({self.to_wkt()})"

--- a/togo.pyx
+++ b/togo.pyx
@@ -655,7 +655,7 @@ cdef class Geometry:
         return tg_geom_equals(self.geom, other_g.geom) != 0
 
     def __hash__(self):
-        return hash(self.to_wkt())
+        return hash(self.to_wkb())
 
     # Shapely-compatible properties
     @property

--- a/togo.pyx
+++ b/togo.pyx
@@ -274,7 +274,10 @@ cdef class Geometry:
             return
         if data is not None and not isinstance(data, str):
             # Non-string data is handled by subclass __init__
+            if type(self) is Geometry:
+                raise TypeError("data must be a str for Geometry()")
             return
+        if data is not None:
         if data is not None:
             if fmt == "geojson":
                 self.geom = tg_parse_geojson(data.encode("utf-8"))

--- a/togo.pyx
+++ b/togo.pyx
@@ -636,9 +636,11 @@ cdef class Geometry:
         """Copy geom pointer from another Geometry (used by Python subclasses)."""
         if self.geom is not NULL:
             tg_geom_free(self.geom)
+            self.geom = NULL
         if other.geom is not NULL:
             self.geom = tg_geom_clone(other.geom)
-
+        else:
+            self.geom = NULL
     def __eq__(self, other):
         if other is None:
             return False

--- a/togo.pyx
+++ b/togo.pyx
@@ -239,6 +239,9 @@ cdef extern from "geos_c.h":
     GEOSGeometry *GEOSIntersection_r(
         GEOSContextHandle_t handle, const GEOSGeometry *g1, const GEOSGeometry *g2
     )
+    double GEOSProject_r(
+        GEOSContextHandle_t handle, const GEOSGeometry *line, const GEOSGeometry *point
+    )
 
 cdef extern from "tgx.h":
     GEOSGeometry *tg_geom_to_geos(GEOSContextHandle_t handle, const tg_geom *geom)
@@ -266,8 +269,11 @@ cdef Line _line_from_ptr(tg_line *ptr):
 cdef class Geometry:
     cdef tg_geom *geom
 
-    def __cinit__(self, data: str = None, fmt: str = "geojson"):
+    def __cinit__(self, data=None, fmt: str = "geojson"):
         if self.geom is not NULL:
+            return
+        if data is not None and not isinstance(data, str):
+            # Non-string data is handled by subclass __init__
             return
         if data is not None:
             if fmt == "geojson":
@@ -396,44 +402,100 @@ cdef class Geometry:
         return tg_geom_num_geometries(self.geom)
 
     def equals(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_equals(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_equals(self.geom, other_g.geom) != 0
 
     def disjoint(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_disjoint(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_disjoint(self.geom, other_g.geom) != 0
 
     def contains(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_contains(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_contains(self.geom, other_g.geom) != 0
 
     def within(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_within(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_within(self.geom, other_g.geom) != 0
 
     def covers(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_covers(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_covers(self.geom, other_g.geom) != 0
 
     def coveredby(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_coveredby(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_coveredby(self.geom, other_g.geom) != 0
 
     def touches(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_touches(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_touches(self.geom, other_g.geom) != 0
 
     def intersects(self, other) -> bool:
-        if other is None or not isinstance(other, Geometry):
+        cdef Geometry other_g
+        if other is None:
             raise TypeError("other must be a Geometry instance")
-        return tg_geom_intersects(self.geom, (<Geometry>other).geom) != 0
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            raise TypeError("other must be a Geometry instance")
+        return tg_geom_intersects(self.geom, other_g.geom) != 0
 
     cdef str _to_string(
         self, size_t (*writer_func)(const tg_geom*, char*, size_t), str format_name
@@ -567,6 +629,30 @@ cdef class Geometry:
     # internal accessor for C pointer
     cdef tg_geom *_get_c_geom(self) noexcept:
         return self.geom
+
+    def _init_from_geometry(self, Geometry other):
+        """Copy geom pointer from another Geometry (used by Python subclasses)."""
+        if self.geom is not NULL:
+            tg_geom_free(self.geom)
+        if other.geom is not NULL:
+            self.geom = tg_geom_clone(other.geom)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        cdef Geometry other_g
+        if isinstance(other, Geometry):
+            other_g = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_g = other.as_geometry()
+        else:
+            return NotImplemented
+        if self.geom is NULL or other_g.geom is NULL:
+            return self.geom is NULL and other_g.geom is NULL
+        return tg_geom_equals(self.geom, other_g.geom) != 0
+
+    def __hash__(self):
+        return hash(self.to_wkt())
 
     # Shapely-compatible properties
     @property
@@ -1325,14 +1411,19 @@ cdef class Geometry:
         cdef tg_geom *empty
         cdef Geometry other_geom
 
-        # Return empty geometry for None or non-Geometry objects (Shapely-compatible behavior)
-        if other is None or not isinstance(other, Geometry):
-            # Return empty geometry collection
+        # Coerce wrapper geometry objects
+        if other is None:
             empty = tg_geom_new_geometrycollection_empty()
             return _geometry_from_ptr(empty)
 
-        # Cast to Geometry for safe access to .geom attribute
-        other_geom = <Geometry>other
+        if isinstance(other, Geometry):
+            other_geom = <Geometry>other
+        elif hasattr(other, "as_geometry"):
+            other_geom = other.as_geometry()
+        else:
+            # Return empty geometry collection
+            empty = tg_geom_new_geometrycollection_empty()
+            return _geometry_from_ptr(empty)
 
         ctx = GEOS_init_r()
         if ctx == NULL:
@@ -1555,6 +1646,24 @@ cdef class Point:
 
     def __repr__(self):
         return self.__str__()
+
+    def __eq__(self, other):
+        if isinstance(other, Point):
+            return self.pt.x == (<Point>other).pt.x and self.pt.y == (<Point>other).pt.y
+        if isinstance(other, Geometry):
+            try:
+                return self.as_geometry().equals(other)
+            except Exception:
+                return False
+        if hasattr(other, "as_geometry"):
+            try:
+                return self.as_geometry().equals(other.as_geometry())
+            except Exception:
+                return False
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.pt.x, self.pt.y))
 
     @property
     def x(self) -> float:
@@ -2467,6 +2576,56 @@ cdef class Line:
         empty = tg_geom_new_geometrycollection_empty()
         return _geometry_from_ptr(empty)
 
+    def project(self, point) -> float:
+        """Return the distance along the line to the nearest point on the line
+        to the given point (Shapely-compatible).
+
+        Parameters:
+        -----------
+        point : Point, Geometry, or any geometry with as_geometry()
+            The point to project onto the line
+
+        Returns:
+        --------
+        float
+            The distance along the line from its start to the projected point
+        """
+        cdef GEOSContextHandle_t ctx
+        cdef GEOSGeometry *g_line
+        cdef GEOSGeometry *g_point
+        cdef double result
+        cdef Geometry line_geom
+        cdef Geometry point_geom
+
+        line_geom = self.as_geometry()
+        if isinstance(point, Geometry):
+            point_geom = <Geometry>point
+        elif hasattr(point, "as_geometry"):
+            point_geom = point.as_geometry()
+        else:
+            raise TypeError("point must be a Point or Geometry")
+
+        ctx = GEOS_init_r()
+        if ctx == NULL:
+            raise RuntimeError("Failed to initialize GEOS context")
+
+        g_line = tg_geom_to_geos(ctx, line_geom._get_c_geom())
+        if g_line == NULL:
+            GEOS_finish_r(ctx)
+            raise RuntimeError("Failed to convert line to GEOS")
+
+        g_point = tg_geom_to_geos(ctx, point_geom._get_c_geom())
+        if g_point == NULL:
+            GEOSGeom_destroy_r(ctx, g_line)
+            GEOS_finish_r(ctx)
+            raise RuntimeError("Failed to convert point to GEOS")
+
+        result = GEOSProject_r(ctx, g_line, g_point)
+        GEOSGeom_destroy_r(ctx, g_point)
+        GEOSGeom_destroy_r(ctx, g_line)
+        GEOS_finish_r(ctx)
+        return result
+
 
 cdef class Poly:
     cdef tg_poly *poly
@@ -2835,6 +2994,40 @@ cdef class Poly:
         empty = tg_geom_new_geometrycollection_empty()
         return _geometry_from_ptr(empty)
 
+    def intersects(self, other) -> bool:
+        """Check if this polygon intersects another geometry (Shapely-compatible).
+
+        Parameters:
+        -----------
+        other : Geometry, Point, Line, Ring, Poly, or other geometry type
+            The other geometry to check intersection with
+
+        Returns:
+        --------
+        bool
+            True if the geometries intersect, False otherwise
+        """
+        if other is None:
+            raise ValueError("other must not be None")
+        if isinstance(other, Geometry):
+            return self.as_geometry().intersects(other)
+        elif hasattr(other, "as_geometry"):
+            return self.as_geometry().intersects(other.as_geometry())
+        raise TypeError(f"other must be a geometry, got {type(other)}")
+
+    @property
+    def boundary(self) -> Line:
+        """Return the exterior boundary of the polygon as a LineString (Shapely-compatible).
+
+        Returns:
+        --------
+        Line
+            The exterior ring as a LineString
+        """
+        ext = self.exterior
+        pts = ext.points(as_tuples=True)
+        return Line(pts)
+
 
 cdef class Segment:
     cdef public tg_segment seg
@@ -2947,25 +3140,108 @@ class Polygon(Poly):
         # Call parent Poly.__init__
         super().__init__(exterior, holes)
 
+    @classmethod
+    def from_bounds(cls, minx, miny, maxx, maxy):
+        """Create a Polygon from bounding box coordinates (Shapely-compatible).
+
+        Parameters:
+        -----------
+        minx, miny, maxx, maxy : float
+            The bounding box coordinates
+
+        Returns:
+        --------
+        Polygon
+            A rectangular Polygon
+        """
+        coords = [
+            (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy), (minx, miny)
+        ]
+        return cls(coords)
+
+
+class MultiPolygon(Geometry):
+    """Shapely-compatible MultiPolygon class (supports isinstance checks).
+
+    Create a MultiPolygon from a list of Poly/Polygon objects or coordinate sequences.
+    """
+
+    def __new__(cls, polys=None):
+        return Geometry.__new__(cls)
+
+    def __init__(self, polys=None):
+        if polys is not None:
+            # Convert Polygon objects to Poly for from_multipolygon
+            converted = []
+            for p in polys:
+                if isinstance(p, Poly):
+                    converted.append(p)
+                else:
+                    converted.append(Polygon(p[0], p[1] if len(p) > 1 else None))
+            tmp = Geometry.from_multipolygon(converted)
+            self._init_from_geometry(tmp)
+
+    def __repr__(self):
+        return f"MultiPolygon({self.to_wkt()})"
+
+
+class MultiLineString(Geometry):
+    """Shapely-compatible MultiLineString class (supports isinstance checks).
+
+    Create a MultiLineString from a list of Line/LineString objects or coordinate sequences.
+    """
+
+    def __new__(cls, lines=None):
+        return Geometry.__new__(cls)
+
+    def __init__(self, lines=None):
+        if lines is not None:
+            tmp = Geometry.from_multilinestring(lines)
+            self._init_from_geometry(tmp)
+
+    def __repr__(self):
+        return f"MultiLineString({self.to_wkt()})"
+
 
 def MultiPoint(points) -> Geometry:
     """Create a MultiPoint geometry from a list of points"""
     return Geometry.from_multipoint(points)
 
 
-def MultiLineString(lines) -> Geometry:
-    """Create a MultiLineString geometry from a list of lines"""
-    return Geometry.from_multilinestring(lines)
-
-
-def MultiPolygon(polys) -> Geometry:
-    """Create a MultiPolygon geometry from a list of polygons"""
-    return Geometry.from_multipolygon(polys)
-
-
 def GeometryCollection(geoms) -> Geometry:
     """Create a GeometryCollection from a list of geometries"""
     return Geometry.from_geometrycollection(geoms)
+
+
+def unary_union(geoms) -> Geometry:
+    """Return the unary union of a sequence of geometries using GEOS (Shapely-compatible).
+
+    Parameters:
+    -----------
+    geoms : sequence of Geometry, Point, Line, Ring, Poly, Polygon, or other geometry types
+        The geometries to union together
+
+    Returns:
+    --------
+    Geometry
+        The union of all input geometries
+
+    Raises:
+    -------
+    ValueError
+        If geoms is empty
+    RuntimeError
+        If the union operation fails
+    """
+    converted = []
+    for g in geoms:
+        if isinstance(g, Geometry):
+            converted.append(g)
+        elif hasattr(g, "as_geometry"):
+            converted.append(g.as_geometry())
+        else:
+            raise TypeError(f"unary_union expects geometry objects, got {type(g)}")
+    return Geometry.unary_union(converted)
 
 
 # Shapely-compatible module-level functions
@@ -3098,6 +3374,7 @@ cdef Geometry _transform_recursive(object func, Geometry geom):
     cdef tg_point pt
     cdef const tg_point *pts
     cdef const tg_point *line_pts
+    cdef Poly transformed_poly
 
     # Point (type 1)
     if geom_type == 1:
@@ -3139,7 +3416,7 @@ cdef Geometry _transform_recursive(object func, Geometry geom):
             transformed_holes.append(Ring(transformed_hole_coords))
 
         transformed_poly = Poly(transformed_ext, transformed_holes if transformed_holes else None)
-        return _geometry_from_ptr(tg_geom_new_polygon(transformed_poly._get_c_poly()))
+        return _geometry_from_ptr(tg_geom_new_polygon((<Poly>transformed_poly)._get_c_poly()))
 
     # MultiPoint (type 4)
     elif geom_type == 4:
@@ -3449,6 +3726,7 @@ __all__ = [
     "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection",
     "from_wkt", "from_geojson", "from_wkb",
     "to_wkt", "to_geojson", "to_wkb",
-    "nearest_points", "shortest_line", "convex_hull", "transform",
+    "unary_union", "nearest_points", "shortest_line", "convex_hull",
+    "intersection", "transform",
     "set_polygon_indexing_mode", "TGIndex"
 ]

--- a/togo.pyx
+++ b/togo.pyx
@@ -3013,10 +3013,10 @@ cdef class Poly:
             True if the geometries intersect, False otherwise
         """
         if other is None:
-            raise ValueError("other must not be None")
+            raise TypeError("other must be a geometry")
         if isinstance(other, Geometry):
             return self.as_geometry().intersects(other)
-        elif hasattr(other, "as_geometry"):
+        if hasattr(other, "as_geometry"):
             return self.as_geometry().intersects(other.as_geometry())
         raise TypeError(f"other must be a geometry, got {type(other)}")
 

--- a/togo.pyx
+++ b/togo.pyx
@@ -278,7 +278,6 @@ cdef class Geometry:
                 raise TypeError("data must be a str for Geometry()")
             return
         if data is not None:
-        if data is not None:
             if fmt == "geojson":
                 self.geom = tg_parse_geojson(data.encode("utf-8"))
             elif fmt == "wkt":
@@ -655,6 +654,8 @@ cdef class Geometry:
         return tg_geom_equals(self.geom, other_g.geom) != 0
 
     def __hash__(self):
+        if self.geom is NULL:
+            return hash(None)
         return hash(self.to_wkb())
 
     # Shapely-compatible properties

--- a/togo.pyx
+++ b/togo.pyx
@@ -2627,6 +2627,8 @@ cdef class Line:
         GEOSGeom_destroy_r(ctx, g_point)
         GEOSGeom_destroy_r(ctx, g_line)
         GEOS_finish_r(ctx)
+        if result < 0:
+            raise RuntimeError("GEOSProject failed")
         return result
 
 


### PR DESCRIPTION
## Summary

Implements the Shapely-compatible API surface required by `model_based_planner`.

## Changes

### New features
- **`unary_union(geoms)`** ? Module-level function that unions a sequence of
  geometry objects using GEOS (accepts `Polygon`, `Point`, `LineString`, etc.
  directly without manual `.as_geometry()` conversion).
- **`LineString.project(point)`** ? Returns the distance along the line to the
  nearest projected point, backed by `GEOSProject_r`.
- **`Polygon.intersects(other)`** ? Spatial predicate on the `Poly`/`Polygon`
  class; coerces wrapper objects automatically.
- **`Polygon.boundary`** ? Property returning the exterior ring as a
  `LineString`.
- **`Polygon.from_bounds(minx, miny, maxx, maxy)`** ? Classmethod to construct
  a rectangular `Polygon` from bounding-box coordinates.

### Fixes & improvements
- **`MultiPolygon` / `MultiLineString`** converted from factory functions to
  real Python classes inheriting from `Geometry`, so `isinstance` checks work
  correctly.
- **All `Geometry` spatial predicates** (`intersects`, `contains`, `within`,
  `covers`, `coveredby`, `touches`, `disjoint`, `equals`, `intersection`) now
  accept wrapper objects (`Point`, `LineString`, `Polygon`, etc.) directly via
  `as_geometry()` coercion ? no manual conversion needed at call sites.
- **`Point.coords` / `LineString.coords`** already supported indexing and
  `len()`; confirmed and covered by tests.
- **`Geometry.__eq__` / `__hash__`** and **`Point.__eq__` / `__hash__`** added
  for consistent equality semantics matching Shapely expectations.

## Tests

Added `tests/test_shapely_compat.py` with **60 new tests** covering every item
above. All 497 tests (437 pre-existing + 60 new) pass.