### PR TITLE
ToGo compatibility gaps with Shapely

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,11 +1,5 @@
 # Quick Reference: ToGo Shapely-Compatible API
 
-## v0.4.1 Notes (vs v0.4.0)
-
-- `LineString.project(..., normalized=True)` is supported.
-- `Geometry.exterior`, `Geometry.interiors`, and `Geometry.boundary` have safer lifetime handling.
-- Mixed-input `unary_union()` coercion is safer (coerced objects are kept alive during union).
-
 ## Installation
 
 ```bash
@@ -16,7 +10,7 @@ pip install togo
 
 ```python
 from togo import Point, LineString, Polygon, Ring
-from togo import from_wkt, from_geojson, to_wkt, to_geojson
+from togo import from_wkt, from_geojson, to_wkt, to_geojson, shape, box
 ```
 
 ## Create Geometries
@@ -148,6 +142,17 @@ multi = MultiPolygon(polys)
 # GeometryCollection
 geoms = [Point(0, 0), LineString([(1, 1), (2, 2)])]
 collection = GeometryCollection(geoms)
+
+# Access children as a tuple
+parts = collection.geoms
+len(parts)
+```
+
+## shape() and box()
+
+```python
+geom = shape({"type": "Point", "coordinates": [1, 2]})
+rect = box(0, 0, 10, 5)
 ```
 
 ## Common Properties
@@ -266,9 +271,9 @@ poly = Poly(Ring([...]))
 | Feature | Shapely | ToGo |
 |---------|---------|------|
 | Predicates | Work on shapes directly | Work on wrapper objects directly |
-| Multi-geometries | Auto-created | Explicit constructors |
+| Multi-geometries | Class-based | Class-based (`isinstance` works) |
 
 ---
 
 **Status:** Production Ready ✅
-**Last Updated:** December 6, 2025
+**Last Updated:** June 8, 2026

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install togo
 - Memory-efficient C implementation with Python-friendly interface
 - Advanced operations via libgeos integration (buffer, unary union, simplify, centroid, convex_hull, etc.)
 - Distance and proximity operations (nearest_points, shortest_line, project)
-- `MultiPolygon` and `MultiLineString` are real Python classes — `isinstance()` checks work correctly
+- `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` are real Python classes — `isinstance()` checks work correctly
 - Geometry equality via `==` operator consistent with Shapely semantics
 
 ## Basic Usage
@@ -84,7 +84,7 @@ if poly.contains(point):
 if poly.intersects(Polygon([(3, 3), (5, 3), (5, 5), (3, 5), (3, 3)])):
     print("Polygons intersect!")
 
-# Polygon.boundary — exterior ring as a LineString
+# Polygon.boundary — LineString (no holes) or MultiLineString (with holes)
 boundary = poly.boundary
 print(boundary.length)     # perimeter of polygon
 
@@ -106,6 +106,12 @@ print(hull.to_wkt())  # 'POLYGON((0 0,2 0,2 2,0 2,0 0))'
 other = Polygon([(3, 3), (5, 3), (5, 5), (3, 5), (3, 3)])
 merged = poly.union(other)
 print(merged.geom_type)
+
+# Shapely-style constructors/helpers
+from togo import shape, box
+g1 = shape({"type": "Point", "coordinates": [1, 2]})
+g2 = box(0, 0, 2, 1)
+print(g1.geom_type, g2.geom_type)
 ```
 
 You can also call the module-level helper with `from togo import union` and then
@@ -122,8 +128,9 @@ The base class that wraps tg_geom structures and provides core operations:
 - Use common predicates such as `intersects()`, `contains()`, and `within()` directly on
   `Geometry` instances.
 - Convert geometries back to WKT/GeoJSON/WKB using `to_wkt()`, `to_geojson()`, and `to_wkb()`.
-- Index collection-like geometries such as `GeometryCollection`, `MultiLineString`, and
+- Index collection-like geometries such as `MultiPoint`, `GeometryCollection`, `MultiLineString`, and
   `MultiPolygon` using `geom[idx]`.
+- Access collection members as an immutable tuple via `.geoms` on multi-geometries and geometry collections.
 - High-risk accessor, predicate, and overlay paths now fail with managed exceptions when used on
   uninitialized base `Geometry()` objects.
 
@@ -244,7 +251,7 @@ print(f"Contains point (1.5,1.5): {geom.contains(Point(1.5,1.5).as_geometry())}"
 
 ### MultiGeometries
 
-`MultiPolygon` and `MultiLineString` are real Python classes, so `isinstance()` checks work correctly:
+All multi-geometries are real Python classes, so `isinstance()` checks work correctly:
 
 ```python
 from togo import MultiPoint, MultiLineString, MultiPolygon, Poly, Ring, Geometry
@@ -260,8 +267,17 @@ print(isinstance(multi_poly, Geometry))      # True
 multi_line = MultiLineString([[(0,0), (1,1)], [(2,2), (3,3)]])
 print(isinstance(multi_line, MultiLineString))  # True
 
-# MultiPoint — factory (returns Geometry)
+# MultiPoint — real class, supports isinstance
 multi_point = MultiPoint([(0,0), (1,1), (2,2)])
+print(isinstance(multi_point, MultiPoint))  # True
+
+# GeometryCollection — real class, supports isinstance
+from togo import GeometryCollection
+collection = GeometryCollection([multi_point, multi_line])
+print(isinstance(collection, GeometryCollection))  # True
+
+# Child members
+print(len(collection.geoms))
 
 # Low-level factory methods still available on Geometry
 multi_poly2 = Geometry.from_multipolygon([poly1, poly2])

--- a/SHAPELY_API.md
+++ b/SHAPELY_API.md
@@ -35,10 +35,10 @@ ToGo provides the following Shapely-compatible class names:
 - `Point` - Create points
 - `LineString` - Create linestrings (alias for `Line`)
 - `Polygon` - Create polygons (subclass of `Poly`)
-- `MultiPoint()` - Create multi-point geometries (returns `Geometry`)
+- `MultiPoint` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
 - `MultiLineString` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
 - `MultiPolygon` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
-- `GeometryCollection()` - Create geometry collections (returns `Geometry`)
+- `GeometryCollection` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
 
 ```python
 from togo import MultiPolygon, MultiLineString, Geometry, Poly, Ring
@@ -135,7 +135,7 @@ print(poly.is_empty)          # False
 print(poly.is_valid)          # True
 print(poly.exterior)          # Ring object (exterior ring)
 print(poly.interiors)         # List of Ring objects (holes)
-print(poly.boundary)          # LineString — the exterior ring as a line
+print(poly.boundary)          # LineString (no holes) or MultiLineString (with holes)
 print(poly.wkt)               # 'POLYGON((0 0,4 0,4 4,0 4,0 0))'
 print(poly.wkb)               # bytes object
 print(poly.__geo_interface__) # GeoJSON-like dict
@@ -173,6 +173,21 @@ print(geojson_geom.geom_type)
 wkb_bytes = bytes.fromhex("0101000000000000000000F03F0000000000000040")
 wkb_geom = from_wkb(wkb_bytes)
 print(wkb_geom.geom_type)
+```
+
+### shape() and box()
+
+```python
+from togo import shape, box
+
+# shape() from GeoJSON-like mapping or __geo_interface__ object
+geom = shape({"type": "Point", "coordinates": [1, 2]})
+print(geom.geom_type)  # 'Point'
+
+# box() from bounds
+rect = box(0, 0, 3, 2)
+print(rect.geom_type)  # 'Polygon'
+print(rect.bounds)     # (0.0, 0.0, 3.0, 2.0)
 ```
 
 ### Serialization Functions
@@ -283,7 +298,10 @@ print(poly.exterior)         # Ring: exterior ring
 print(poly.interiors)        # List[Ring]: list of holes
 print(poly.centroid)         # Point: center of mass
 print(poly.boundary)         # LineString: exterior ring as a line
+print(poly_with_hole.boundary)  # MultiLineString: exterior + interior rings
 ```
+
+For multi-geometries and geometry collections, use `.geoms` to access members as a tuple.
 
 ## Spatial Predicates
 
@@ -570,10 +588,10 @@ control flow, while null/uninitialized geometry bugs are surfaced earlier and mo
 1. **Class names**: `Point`, `LineString`, `Polygon`
 2. **Properties**: `geom_type`, `bounds`, `area`, `coords`, `is_empty`, `is_valid`
 3. **Serialization**: `wkt`, `wkb`, `__geo_interface__`
-4. **Module functions**: `from_wkt()`, `from_geojson()`, `to_wkt()`, `unary_union()`, `union()`, `force_2d()`
+4. **Module functions**: `from_wkt()`, `from_geojson()`, `to_wkt()`, `shape()`, `box()`, `unary_union()`, `union()`, `force_2d()`
 5. **Predicates**: `contains()`, `intersects()`, `touches()`, `within()`, `covers()`, `coveredby()`, `equals()`
 6. **Operations**: `intersection()`, `union()`, `buffer()`, `simplify()`, `project()`
-7. **Multi-geometry classes**: `MultiPolygon`, `MultiLineString` are real Python classes, `isinstance()` works
+7. **Multi-geometry classes**: `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` are real Python classes, `isinstance()` works
 8. **Equality**: `geom1 == geom2` works consistently, geometries are hashable
 
 ### Differences
@@ -634,7 +652,7 @@ print(f"Stop is at {road.project(stop.as_geometry()):.1f}m along the road")  # 4
 bbox = Polygon.from_bounds(0, 0, 10, 5)
 print(f"BBox area: {bbox.area}")   # 50.0
 
-# Polygon.boundary — exterior ring as a LineString
+# Polygon.boundary — LineString (no holes) or MultiLineString (with holes)
 print(f"Perimeter via boundary: {poly.boundary.length:.2f}")  # same as poly.length
 
 # Spatial predicates — no .as_geometry() needed
@@ -777,8 +795,10 @@ The `transform` function works with:
 | `LineString(coords)` | `LineString(coords)` | ✅ |
 | `Polygon(shell, holes)` | `Polygon(shell, holes=[...])` | ✅ |
 | `Polygon.from_bounds(x1,y1,x2,y2)` | `Polygon.from_bounds(x1,y1,x2,y2)` | ✅ |
+| `MultiPoint(points)` | `MultiPoint(points)` | ✅ Real class; `isinstance` works |
 | `MultiPolygon(polys)` | `MultiPolygon(polys)` | ✅ Real class; `isinstance` works |
 | `MultiLineString(lines)` | `MultiLineString(lines)` | ✅ Real class; `isinstance` works |
+| `GeometryCollection(geoms)` | `GeometryCollection(geoms)` | ✅ Real class; `isinstance` works |
 | `geom.geom_type` | `geom.geom_type` | ✅ |
 | `geom.bounds` | `geom.bounds` | ✅ |
 | `geom.area` | `geom.area` | ✅ |
@@ -786,6 +806,7 @@ The `transform` function works with:
 | `geom.centroid` | `geom.centroid` | ✅ via GEOS |
 | `geom.convex_hull` | `geom.convex_hull` | ✅ via GEOS |
 | `geom.boundary` | `poly.boundary` | ✅ on Polygon/Poly |
+| `geom.geoms` | `geom.geoms` | ✅ on multi-geometries and GeometryCollection |
 | `geom.is_empty` | `geom.is_empty` | ✅ |
 | `geom.is_valid` | `geom.is_valid` | ✅ via GEOS |
 | `geom.coords` | `geom.coords` | ✅ Indexable; `coords[i]` and `len()` work |
@@ -797,6 +818,8 @@ The `transform` function works with:
 | `geom1 == geom2` | `geom1 == geom2` | ✅ |
 | `from_wkt()` | `from_wkt()` | ✅ |
 | `from_geojson()` | `from_geojson()` | ✅ |
+| `shape(mapping_or_geo_interface)` | `shape(mapping_or_geo_interface)` | ✅ |
+| `box(minx,miny,maxx,maxy)` | `box(minx,miny,maxx,maxy)` | ✅ |
 | `to_wkt()` | `to_wkt()` | ✅ |
 | `geom.contains(other)` | `geom.contains(other)` | ✅ Accepts wrapper objects directly |
 | `geom.intersects(other)` | `geom.intersects(other)` | ✅ Accepts wrapper objects directly |
@@ -823,9 +846,10 @@ The `transform` function works with:
 ToGo provides a comprehensive Shapely-compatible API that makes it easy to migrate from Shapely or use it as a drop-in replacement for common geometric operations. Key highlights:
 
 - **Wrapper objects are first-class citizens** — all spatial predicates and operations accept `Point`, `LineString`, `Polygon`, etc. directly without calling `.as_geometry()`.
-- **`MultiPolygon` and `MultiLineString` are real Python classes** — `isinstance()` checks work as expected.
+- **`MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` are real Python classes** — `isinstance()` checks work as expected.
+- **`shape()` and `box()`** are available as module-level Shapely-style helpers.
 - **`unary_union(geoms)`**, **`union(g1, g2)`**, and **`force_2d(geom)`** are proper module-level functions aligned with Shapely's API.
-- **New Polygon conveniences**: `from_bounds()`, `boundary`, `intersects()`.
+- **New Polygon conveniences**: `from_bounds()`, improved `boundary`, `intersects()`.
 - **`LineString.project()`** for measuring distance-along-line projections.
 - **Geometry equality** via `==` and hashability are supported on all geometry types.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "togo"
-version = "0.4.4"
+version = "0.4.5"
 description = "Lightweight Python bindings for the TG geometry library"
 readme = "README.md"
 authors = [

--- a/tests/test_pickle_boundary_compat.py
+++ b/tests/test_pickle_boundary_compat.py
@@ -2,7 +2,7 @@ import pickle
 from concurrent.futures import ProcessPoolExecutor
 import multiprocessing as mp
 
-from togo import Geometry, LineString, Point, Polygon
+from togo import Geometry, GeometryCollection, LineString, MultiPoint, Point, Polygon
 
 
 def _wkb_of(obj):
@@ -54,6 +54,8 @@ def test_pickle_roundtrip_core_geometry_types():
         Point(0.1, 0.2),
         LineString([(0, 0), (1, 1)]),
         poly,
+        MultiPoint([(0, 0), (1, 1)]),
+        GeometryCollection([Point(0, 0), LineString([(0, 0), (1, 0)])]),
         poly.exterior,
         poly.boundary,
         poly.as_geometry(),

--- a/tests/test_shapely_api.py
+++ b/tests/test_shapely_api.py
@@ -540,6 +540,27 @@ class TestModuleLevelFunctions:
         # Bounds should be approximately equal
         assert geom2.bounds == pytest.approx(geom1.bounds)
 
+    def test_shape_from_geojson_mapping(self):
+        from togo import shape
+
+        geom = shape({"type": "Point", "coordinates": [2, 3]})
+        assert geom.geom_type == "Point"
+        assert geom.coords == [(2.0, 3.0)]
+
+    def test_shape_from_geo_interface_object(self):
+        from togo import shape, Point
+
+        geom = shape(Point(4, 5))
+        assert geom.geom_type == "Point"
+        assert geom.coords == [(4.0, 5.0)]
+
+    def test_box_creates_polygon_from_bounds(self):
+        from togo import box
+
+        geom = box(0, 1, 3, 4)
+        assert geom.geom_type == "Polygon"
+        assert geom.bounds == (0.0, 1.0, 3.0, 4.0)
+
     def test_to_wkt_from_point(self):
         from togo import Point, to_wkt
 
@@ -652,6 +673,23 @@ class TestMultiGeometries:
         geoms = [Point(0, 0), LineString([(1, 1), (2, 2)])]
         collection = GeometryCollection(geoms)
         assert collection.geom_type == "GeometryCollection"
+
+    def test_multi_geoms_property(self):
+        from togo import MultiPoint
+
+        multi = MultiPoint([(0, 0), (1, 1), (2, 2)])
+        children = multi.geoms
+        assert isinstance(children, tuple)
+        assert len(children) == 3
+        assert [g.geom_type for g in children] == ["Point", "Point", "Point"]
+
+    def test_geometry_collection_geoms_property(self):
+        from togo import GeometryCollection, Point, LineString
+
+        collection = GeometryCollection([Point(0, 0), LineString([(1, 1), (2, 2)])])
+        children = collection.geoms
+        assert isinstance(children, tuple)
+        assert [g.geom_type for g in children] == ["Point", "LineString"]
 
 
 class TestSpatialPredicates:

--- a/tests/test_shapely_api.py
+++ b/tests/test_shapely_api.py
@@ -642,6 +642,14 @@ class TestMultiGeometries:
         points = [(0, 0), (1, 1), (2, 2)]
         multi = MultiPoint(points)
         assert multi.geom_type == "MultiPoint"
+    
+    def test_multipoint_getitem_returns_point(self):
+        from togo import MultiPoint
+
+        mp = MultiPoint([(0, 0), (1, 1), (2, 2)])
+        p = mp[1]
+        assert p.geom_type == "Point"
+        assert p.coords == [(1.0, 1.0)]
 
     def test_multilinestring_creation(self):
         from togo import MultiLineString, LineString
@@ -690,6 +698,36 @@ class TestMultiGeometries:
         children = collection.geoms
         assert isinstance(children, tuple)
         assert [g.geom_type for g in children] == ["Point", "LineString"]
+
+    def test_multilinestring_geoms_property(self):
+        from togo import MultiLineString
+
+        multi = MultiLineString([[(0, 0), (1, 1)], [(2, 2), (3, 3)]])
+        children = multi.geoms
+        assert isinstance(children, tuple)
+        assert [g.geom_type for g in children] == ["LineString", "LineString"]
+
+    def test_multipolygon_geoms_property(self):
+        from togo import MultiPolygon, Polygon
+
+        multi = MultiPolygon([
+            Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]),
+            Polygon([(3, 3), (4, 3), (4, 4), (3, 4), (3, 3)]),
+        ])
+        children = multi.geoms
+        assert isinstance(children, tuple)
+        assert [g.geom_type for g in children] == ["Polygon", "Polygon"]
+
+    def test_polygon_boundary_with_holes_returns_multilinestring(self):
+        from togo import Polygon
+
+        poly = Polygon(
+            [(0, 0), (4, 0), (4, 4), (0, 4), (0, 0)],
+            holes=[[(1, 1), (1, 2), (2, 2), (2, 1), (1, 1)]],
+        )
+        b = poly.boundary
+        assert b.geom_type == "MultiLineString"
+        assert len(b.geoms) == 2
 
 
 class TestSpatialPredicates:

--- a/togo.pyx
+++ b/togo.pyx
@@ -3587,17 +3587,23 @@ cdef class Poly:
         return self.as_geometry().intersects(other_g)
 
     @property
-    def boundary(self) -> Line:
-        """Return the exterior boundary of the polygon as a LineString (Shapely-compatible).
+    def boundary(self):
+        """Return the polygon boundary as LineString or MultiLineString (Shapely-compatible).
 
         Returns:
         --------
-        Line
-            The exterior ring as a LineString
+        Line or MultiLineString
+            Exterior ring as LineString, or exterior + holes as MultiLineString
         """
         ext = self.exterior
+        holes = self.interiors
         pts = ext.points(as_tuples=True)
-        return Line(pts)
+        if len(holes) == 0:
+            return Line(pts)
+        lines = [pts]
+        for hole in holes:
+            lines.append(hole.points(as_tuples=True))
+        return MultiLineString(lines)
 
 
 cdef class Segment:

--- a/togo.pyx
+++ b/togo.pyx
@@ -693,11 +693,18 @@ cdef class Geometry:
         cdef const tg_geom *g
         cdef int t = tg_geom_typeof(self.geom)
         cdef int n
+        cdef tg_point pt
         cdef const tg_line *ln
         cdef const tg_poly *poly
         # 1: Point, 2: LineString, 3: Polygon, 4: MultiPoint,
         # 5: MultiLineString, 6: MultiPolygon, 7: GeometryCollection
-        if t == 5:  # MultiLineString
+        if t == 4:  # MultiPoint
+            n = tg_geom_num_points(self.geom)
+            if not (0 <= idx < n):
+                raise IndexError("MultiPoint index out of range")
+            pt = tg_geom_point_at(self.geom, idx)
+            return _geometry_from_ptr(tg_geom_new_point(pt))
+        elif t == 5:  # MultiLineString
             n = tg_geom_num_lines(self.geom)
             if not (0 <= idx < n):
                 raise IndexError("MultiLineString index out of range")
@@ -890,15 +897,30 @@ cdef class Geometry:
     @property
     def boundary(self):
         cdef int t = tg_geom_typeof(self.geom)
-        cdef int n, i, n_pts, k
+        cdef int n, i, j, n_pts, k, n_holes
         cdef const tg_poly *poly
         cdef const tg_ring *ext
+        cdef const tg_ring *hole
         cdef const tg_point *pts_ptr
         cdef list lines
         cdef Ring ext_ring
         if t == 3:
-            ext_ring = self.exterior
-            return Line(ext_ring.points(as_tuples=True))
+            poly = tg_geom_poly(self.geom)
+            n_holes = tg_poly_num_holes(poly)
+            if n_holes == 0:
+                ext_ring = self.exterior
+                return Line(ext_ring.points(as_tuples=True))
+            lines = []
+            ext = tg_poly_exterior(poly)
+            n_pts = tg_ring_num_points(ext)
+            pts_ptr = tg_ring_points(ext)
+            lines.append([(pts_ptr[k].x, pts_ptr[k].y) for k in range(n_pts)])
+            for i in range(n_holes):
+                hole = tg_poly_hole_at(poly, i)
+                n_pts = tg_ring_num_points(hole)
+                pts_ptr = tg_ring_points(hole)
+                lines.append([(pts_ptr[k].x, pts_ptr[k].y) for k in range(n_pts)])
+            return MultiLineString(lines)
         if t == 6:
             n = tg_geom_num_polys(self.geom)
             lines = []
@@ -908,8 +930,53 @@ cdef class Geometry:
                 n_pts = tg_ring_num_points(ext)
                 pts_ptr = tg_ring_points(ext)
                 lines.append([(pts_ptr[k].x, pts_ptr[k].y) for k in range(n_pts)])
+                n_holes = tg_poly_num_holes(poly)
+                for j in range(n_holes):
+                    hole = tg_poly_hole_at(poly, j)
+                    n_pts = tg_ring_num_points(hole)
+                    pts_ptr = tg_ring_points(hole)
+                    lines.append([(pts_ptr[k].x, pts_ptr[k].y) for k in range(n_pts)])
             return MultiLineString(lines)
         raise AttributeError(f"boundary not available for {self.type_string()}")
+
+    @property
+    def geoms(self):
+        """Return child geometries for multi and collection geometries."""
+        cdef int t = tg_geom_typeof(self.geom)
+        cdef int n, i
+        cdef tg_point pt
+        cdef const tg_line *ln
+        cdef const tg_poly *poly
+        cdef const tg_geom *g
+        cdef list result
+
+        result = []
+        if t == 4:
+            n = tg_geom_num_points(self.geom)
+            for i in range(n):
+                pt = tg_geom_point_at(self.geom, i)
+                result.append(_geometry_from_ptr(tg_geom_new_point(pt)))
+            return tuple(result)
+        if t == 5:
+            n = tg_geom_num_lines(self.geom)
+            for i in range(n):
+                ln = tg_geom_line_at(self.geom, i)
+                result.append(_geometry_from_ptr(tg_geom_new_linestring(<tg_line *>ln)))
+            return tuple(result)
+        if t == 6:
+            n = tg_geom_num_polys(self.geom)
+            for i in range(n):
+                poly = tg_geom_poly_at(self.geom, i)
+                result.append(_geometry_from_ptr(tg_geom_new_polygon(<tg_poly *>poly)))
+            return tuple(result)
+        if t == 7:
+            n = tg_geom_num_geometries(self.geom)
+            for i in range(n):
+                g = tg_geom_geometry_at(self.geom, i)
+                if g != NULL:
+                    result.append(_geometry_from_ptr(tg_geom_clone(g)))
+            return tuple(result)
+        raise AttributeError(f"geoms not available for {self.type_string()}")
 
     @property
     def __geo_interface__(self) -> dict:
@@ -3715,14 +3782,36 @@ class MultiLineString(Geometry):
         return f"MultiLineString({self.to_wkt()})"
 
 
-def MultiPoint(points) -> Geometry:
-    """Create a MultiPoint geometry from a list of points"""
-    return Geometry.from_multipoint(points)
+class MultiPoint(Geometry):
+    """Shapely-compatible MultiPoint class (supports isinstance checks)."""
+
+    def __new__(cls, points=None):
+        return Geometry.__new__(cls)
+
+    def __init__(self, points=None):
+        if points is None:
+            points = []
+        tmp = Geometry.from_multipoint(points)
+        self._init_from_geometry(tmp)
+
+    def __repr__(self):
+        return f"MultiPoint({self.to_wkt()})"
 
 
-def GeometryCollection(geoms) -> Geometry:
-    """Create a GeometryCollection from a list of geometries"""
-    return Geometry.from_geometrycollection(geoms)
+class GeometryCollection(Geometry):
+    """Shapely-compatible GeometryCollection class (supports isinstance checks)."""
+
+    def __new__(cls, geoms=None):
+        return Geometry.__new__(cls)
+
+    def __init__(self, geoms=None):
+        if geoms is None:
+            geoms = []
+        tmp = Geometry.from_geometrycollection(geoms)
+        self._init_from_geometry(tmp)
+
+    def __repr__(self):
+        return f"GeometryCollection({self.to_wkt()})"
 
 
 def unary_union(geoms) -> Geometry:
@@ -3746,6 +3835,41 @@ def unary_union(geoms) -> Geometry:
         If the union operation fails
     """
     return Geometry.unary_union(list(geoms))
+
+
+def shape(obj) -> Geometry:
+    """Create a Geometry from a GeoJSON-like mapping or JSON text."""
+    import json
+
+    if obj is None:
+        raise TypeError("shape() argument cannot be None")
+
+    if hasattr(obj, "__geo_interface__"):
+        obj = obj.__geo_interface__
+
+    if isinstance(obj, (bytes, bytearray)):
+        obj = obj.decode("utf-8")
+
+    if isinstance(obj, str):
+        return from_geojson(obj)
+
+    if isinstance(obj, dict):
+        return from_geojson(json.dumps(obj))
+
+    raise TypeError("shape() requires a GeoJSON mapping/string or __geo_interface__ object")
+
+
+def box(minx, miny, maxx, maxy, ccw=True) -> Polygon:
+    """Create a rectangular polygon from bounds (Shapely-compatible)."""
+    if ccw:
+        coords = [
+            (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy), (minx, miny)
+        ]
+    else:
+        coords = [
+            (minx, miny), (minx, maxy), (maxx, maxy), (maxx, miny), (minx, miny)
+        ]
+    return Polygon(coords)
 
 
 # Shapely-compatible module-level functions
@@ -4411,7 +4535,7 @@ __all__ = [
     "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection",
     "from_wkt", "from_geojson", "from_wkb",
     "to_wkt", "to_geojson", "to_wkb",
-    "unary_union", "nearest_points", "shortest_line", "convex_hull",
+    "unary_union", "shape", "box", "nearest_points", "shortest_line", "convex_hull",
     "intersection", "union", "transform", "force_2d",
     "set_polygon_indexing_mode", "TGIndex"
 ]


### PR DESCRIPTION
## Summary

This MR closes key ToGo compatibility gaps observed in MBP by improving Shapely-parity APIs and multi-geometry behavior.

### What changed

- Added native module helpers:
  - `shape(...)` for GeoJSON dict/string and `__geo_interface__` inputs
  - `box(minx, miny, maxx, maxy, ccw=True)`
- Made multi-geometry symbols class-based for stable typing:
  - `MultiPoint` and `GeometryCollection` are now classes (not function factories), improving `isinstance` behavior.
- Added `Geometry.geoms` for multi/collection geometries:
  - Supports `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection`.
- Extended `Geometry.__getitem__` to support `MultiPoint` indexing.
- Improved boundary parity:
  - `Polygon.boundary` now includes hole boundaries (returns `MultiLineString` when holes exist).
  - `MultiPolygon.boundary` now includes boundaries for both exteriors and holes.
- Exported new helpers via `__all__`.

### Tests

- Added/updated compatibility coverage in:
  - `tests/test_shapely_api.py`
  - `tests/test_pickle_boundary_compat.py`
- Validated with:

`125 passed` across `tests/test_shapely_api.py` and `tests/test_pickle_boundary_compat.py`.

### Why this matters

These changes reduce downstream shims in MBP by providing missing native API surface and more predictable geometry typing/serialization behavior.