### PR TITLE
Fix native-layer stability

### DIFF
--- a/tests/test_stability_fixes.py
+++ b/tests/test_stability_fixes.py
@@ -1,0 +1,371 @@
+"""
+Regression tests for native-layer stability fixes.
+
+Covers:
+- tg_geom_error propagation after tg_geom_from_geos in all overlay methods
+- Correct GEOSCoordSeq_getXY_r return-value semantics (was checking -1, should be != 1)
+- 2D dimensionality guard in unary_union
+- tg_geom_error propagation after tg_geom_to/from_meters_grid
+- Explicit temporary Line lifetime in _transform_recursive
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _poly(coords):
+    from togo import Polygon
+
+    return Polygon(coords)
+
+
+def _simple_square(offset=0):
+    o = offset
+    return _poly([(o, o), (o + 2, o), (o + 2, o + 2), (o, o + 2), (o, o)])
+
+
+# ---------------------------------------------------------------------------
+# 1. GEOS overlay operations must not silently use error geometries
+# ---------------------------------------------------------------------------
+
+
+class TestOverlayReturnSanity:
+    """All overlay operations should return a valid, accessible Geometry."""
+
+    def test_buffer_result_is_accessible(self):
+        from togo import Point
+
+        g = Point(0, 0).buffer(1.0)
+        assert g.geom_type == "Polygon"
+        assert g.area > 0
+
+    def test_simplify_result_is_accessible(self):
+        poly = _simple_square()
+        result = poly.simplify(0.01)
+        assert result.geom_type in {"Polygon", "MultiPolygon", "GeometryCollection"}
+
+    def test_centroid_result_is_accessible(self):
+        from togo import Geometry
+
+        poly = Geometry("POLYGON((0 0,4 0,4 4,0 4,0 0))", fmt="wkt")
+        c = poly.centroid
+        assert c.geom_type == "Point"
+        # centroid of axis-aligned square at (0,0)–(4,4) is (2,2)
+        assert abs(c.bounds[0] - 2.0) < 1e-9
+        assert abs(c.bounds[1] - 2.0) < 1e-9
+
+    def test_convex_hull_result_is_accessible(self):
+        from togo import MultiPoint
+
+        pts = MultiPoint([(0, 0), (2, 0), (1, 2)])
+        hull = pts.convex_hull
+        assert hull.geom_type in {"Polygon", "LineString", "Point"}
+
+    def test_intersection_result_is_accessible(self):
+        p1 = _simple_square(0)
+        p2 = _simple_square(1)
+        result = p1.intersection(p2)
+        # overlapping squares produce a polygon
+        assert result.geom_type in {"Polygon", "MultiPolygon", "GeometryCollection"}
+        assert result.area == pytest.approx(1.0)
+
+    def test_union_result_is_accessible(self):
+        p1 = _simple_square(0)
+        p2 = _simple_square(1)
+        result = p1.union(p2)
+        assert result.geom_type in {"Polygon", "MultiPolygon"}
+        assert result.area == pytest.approx(7.0)
+
+    def test_unary_union_result_is_accessible(self):
+        from togo import Geometry
+
+        polys = [_simple_square(i) for i in range(3)]
+        result = Geometry.unary_union(polys)
+        assert not result.is_empty
+        # three touching squares give a merged polygon
+        assert result.geom_type in {"Polygon", "MultiPolygon"}
+
+    def test_intersection_disjoint_returns_empty(self):
+        p1 = _simple_square(0)
+        p2 = _simple_square(10)  # far away, no overlap
+        result = p1.intersection(p2)
+        assert result.is_empty
+
+    def test_module_level_intersection_result_is_accessible(self):
+        from togo import intersection
+
+        p1 = _simple_square(0)
+        p2 = _simple_square(1)
+        result = intersection(p1, p2)
+        assert result.area == pytest.approx(1.0)
+
+    def test_module_level_union_result_is_accessible(self):
+        from togo import union
+
+        p1 = _simple_square(0)
+        p2 = _simple_square(1)
+        result = union(p1, p2)
+        assert result.area == pytest.approx(7.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. unary_union 2D dimensionality guard
+# ---------------------------------------------------------------------------
+
+
+class TestUnaryUnion2DGuard:
+    """unary_union must reject 3D geometries instead of proceeding silently."""
+
+    def test_unary_union_2d_list_succeeds(self):
+        from togo import Geometry
+
+        polys = [_simple_square(i * 3) for i in range(4)]
+        result = Geometry.unary_union(polys)
+        assert not result.is_empty
+
+    def test_unary_union_rejects_3d_geometry(self):
+        from togo import Geometry
+
+        # Parse a 3D polygon (has Z coordinate)
+        g3d = Geometry("POLYGON Z ((0 0 1, 2 0 1, 2 2 1, 0 2 1, 0 0 1))", fmt="wkt")
+        assert g3d.has_z, "test precondition: geometry should be 3D"
+        with pytest.raises((ValueError, RuntimeError), match="2D"):
+            Geometry.unary_union([g3d])
+
+    def test_module_level_unary_union_2d_succeeds(self):
+        from togo import unary_union
+
+        polys = [_simple_square(0), _simple_square(3)]
+        result = unary_union(polys)
+        assert not result.is_empty
+
+    def test_unary_union_empty_list_raises(self):
+        from togo import Geometry
+
+        with pytest.raises(ValueError):
+            Geometry.unary_union([])
+
+
+# ---------------------------------------------------------------------------
+# 3. Nearest-points coordinate extraction (GEOSCoordSeq_getXY_r return check)
+# ---------------------------------------------------------------------------
+
+
+class TestNearestPointsCoordExtraction:
+    """Nearest-points extraction must not silently swallow GEOS failures."""
+
+    def test_nearest_points_returns_correct_coordinates(self):
+        from togo import Point, LineString
+
+        p = Point(0, 0)
+        line = LineString([(3, 4), (10, 4)])
+        pt_from_p, pt_from_line = p.nearest_points(line)
+        # Nearest point on line to origin is (3, 4)
+        assert pt_from_p.x == pytest.approx(0.0)
+        assert pt_from_p.y == pytest.approx(0.0)
+        assert pt_from_line.x == pytest.approx(3.0)
+        assert pt_from_line.y == pytest.approx(4.0)
+
+    def test_nearest_points_between_polygons(self):
+        from togo import nearest_points
+
+        p1 = _simple_square(0)  # (0,0)-(2,2)
+        p2 = _simple_square(5)  # (5,5)-(7,7)
+        pt1, pt2 = nearest_points(p1, p2)
+        # nearest corners are (2,2) and (5,5)
+        assert pt1.x == pytest.approx(2.0)
+        assert pt1.y == pytest.approx(2.0)
+        assert pt2.x == pytest.approx(5.0)
+        assert pt2.y == pytest.approx(5.0)
+
+    def test_shortest_line_length_is_correct(self):
+        from togo import shortest_line, Point
+        import math
+
+        p = Point(0, 0)
+        line_geom = _simple_square(3).as_geometry()  # shifted square
+        sl = shortest_line(p, line_geom)
+        # distance from origin to nearest corner (3,3) ≈ 4.2426
+        expected = math.sqrt(3**2 + 3**2)
+        assert sl.length == pytest.approx(expected, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 4. transform recursive – LineString temporary lifetime
+# ---------------------------------------------------------------------------
+
+
+class TestTransformLineStringLifetime:
+    """transform() must keep its temporary Line alive until tg copies the data."""
+
+    def test_transform_linestring(self):
+        from togo import transform, LineString
+
+        line = LineString([(0, 0), (1, 0), (2, 0)])
+        shifted = transform(lambda x, y: (x + 10, y + 5), line)
+        assert shifted.geom_type == "LineString"
+        coords = shifted.coords
+        assert len(coords) == 3
+        assert coords[0] == pytest.approx((10.0, 5.0))
+        assert coords[1] == pytest.approx((11.0, 5.0))
+        assert coords[2] == pytest.approx((12.0, 5.0))
+
+    def test_transform_linestring_many_points(self):
+        """Stress test with many coordinates to stress the temporary object path."""
+        from togo import transform, LineString
+
+        pts = [(float(i), float(i) * 2) for i in range(1000)]
+        line = LineString(pts)
+        result = transform(lambda x, y: (x * 2, y * 2), line)
+        assert result.geom_type == "LineString"
+        result_coords = result.coords
+        assert len(result_coords) == 1000
+        assert result_coords[0] == pytest.approx((0.0, 0.0))
+        assert result_coords[999] == pytest.approx((1998.0, 3996.0))
+
+    def test_transform_multilinestring(self):
+        from togo import transform, Geometry
+
+        mls = Geometry.from_multilinestring([[(0, 0), (1, 1)], [(2, 2), (3, 3)]])
+        result = transform(lambda x, y: (x + 1, y + 1), mls)
+        assert result.geom_type == "MultiLineString"
+
+    def test_transform_polygon(self):
+        from togo import transform
+
+        poly = _simple_square(0)
+        result = transform(lambda x, y: (x + 1, y + 1), poly)
+        assert result.geom_type == "Polygon"
+        assert result.area == pytest.approx(4.0)
+
+    def test_transform_multipolygon(self):
+        from togo import transform, Geometry
+
+        mp = Geometry.from_multipolygon(
+            [
+                _simple_square(0).as_geometry().poly(),
+                _simple_square(5).as_geometry().poly(),
+            ]
+        )
+        result = transform(lambda x, y: (x * 2, y * 2), mp)
+        assert result.geom_type == "MultiPolygon"
+
+    def test_transform_collection(self):
+        from togo import transform, Geometry, Point
+
+        gc = Geometry.from_geometrycollection(
+            [
+                Point(1, 1).as_geometry(),
+                _simple_square(0).as_geometry(),
+            ]
+        )
+        result = transform(lambda x, y: (x - 1, y - 1), gc)
+        assert result.geom_type == "GeometryCollection"
+
+
+# ---------------------------------------------------------------------------
+# 5. meters_grid conversion error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestMetersGridErrorPropagation:
+    """to_meters_grid / from_meters_grid must not silently use error geometries."""
+
+    def test_to_meters_grid_point_roundtrip(self):
+        from togo import Geometry, Point
+
+        g = Geometry("POINT(1 1)", fmt="wkt")
+        origin = Point(0, 0)
+        converted = g.to_meters_grid(origin)
+        # should return a valid (non-empty) geometry
+        assert not converted.is_empty
+        back = converted.from_meters_grid(origin)
+        assert back.geom_type == "Point"
+
+    def test_from_meters_grid_polygon_roundtrip(self):
+        from togo import Geometry, Point
+
+        poly = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", fmt="wkt")
+        origin = Point(0.5, 0.5)
+        converted = poly.to_meters_grid(origin)
+        assert not converted.is_empty
+        back = converted.from_meters_grid(origin)
+        assert back.geom_type == "Polygon"
+
+    def test_to_meters_grid_empty_returns_empty(self):
+        """Empty geometry should survive meters_grid round-trip without crashing."""
+        from togo import Geometry, Point
+
+        empty = Geometry('{"type":"GeometryCollection","geometries":[]}')
+        assert empty.is_empty
+        origin = Point(0, 0)
+        # Should not crash; empty geometry clones are returned early.
+        converted = empty.to_meters_grid(origin)
+        assert converted.is_empty
+
+
+# ---------------------------------------------------------------------------
+# 6. Operation-chain stress – unary_union -> intersection -> buffer chain
+# ---------------------------------------------------------------------------
+
+
+class TestOperationChainSafety:
+    """Simulate the area-slicer workflow: union -> intersection -> buffer."""
+
+    def test_union_then_intersection(self):
+        from togo import Geometry
+
+        # Build two overlapping polygon groups
+        group_a = [_simple_square(i) for i in [0, 1, 2]]
+        group_b = [_simple_square(i) for i in [1, 2, 3]]
+        union_a = Geometry.unary_union(group_a)
+        union_b = Geometry.unary_union(group_b)
+        ix = union_a.intersection(union_b)
+        assert not ix.is_empty
+        # Intersection should be smaller than either union
+        assert ix.area < union_a.area
+        assert ix.area < union_b.area
+        # Intersection must be at least as large as a single shared square (area=4)
+        assert ix.area >= 4.0
+
+    def test_unary_union_then_buffer(self):
+        from togo import Geometry
+
+        polys = [_simple_square(i * 3) for i in range(3)]
+        merged = Geometry.unary_union(polys)
+        buffered = merged.buffer(0.1)
+        assert buffered.area > merged.area
+
+    def test_intersection_chain_is_stable(self):
+        """Repeatedly intersect progressively smaller regions."""
+        from togo import Geometry
+
+        current = Geometry("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", fmt="wkt")
+        for step in range(5):
+            clip = Geometry(
+                f"POLYGON(({step} {step}, 10 {step}, 10 10, {step} 10, {step} {step}))",
+                fmt="wkt",
+            )
+            current = current.intersection(clip)
+            assert not current.is_empty
+
+    def test_unary_union_with_shapely_like_objects(self):
+        """Objects with .wkb attribute (Shapely-style) should work without crashing."""
+        from togo import Geometry
+
+        class FakeShapelyGeom:
+            """Minimal Shapely-like shim with .wkb."""
+
+            def __init__(self, wkb_bytes):
+                self.wkb = wkb_bytes
+
+        poly = _simple_square(0)
+        wkb_bytes = poly.as_geometry().to_wkb()
+        fake = FakeShapelyGeom(wkb_bytes)
+
+        result = Geometry.unary_union([poly.as_geometry(), fake])
+        assert not result.is_empty

--- a/togo.pyx
+++ b/togo.pyx
@@ -657,6 +657,10 @@ cdef class Geometry:
         g2 = tg_geom_to_meters_grid(self.geom, origin._get_c_point())
         if not g2:
             raise ValueError("tgx meters grid conversion failed")
+        if tg_geom_error(g2) != NULL:
+            err_msg = tg_geom_error(g2).decode("utf-8")
+            tg_geom_free(g2)
+            raise ValueError(f"tgx meters grid conversion error: {err_msg}")
         return _geometry_from_ptr(g2)
 
     def from_meters_grid(self, origin: Point) -> Geometry:
@@ -672,6 +676,10 @@ cdef class Geometry:
         g2 = tg_geom_from_meters_grid(self.geom, origin._get_c_point())
         if not g2:
             raise ValueError("tgx from meters grid conversion failed")
+        if tg_geom_error(g2) != NULL:
+            err_msg = tg_geom_error(g2).decode("utf-8")
+            tg_geom_free(g2)
+            raise ValueError(f"tgx from meters grid conversion error: {err_msg}")
         return _geometry_from_ptr(g2)
 
     cpdef Point point(self):
@@ -1276,6 +1284,18 @@ cdef class Geometry:
         cdef int n = _checked_c_count(geoms, "geoms")
         if n == 0:
             raise ValueError("unary_union requires at least one geometry")
+        # Pre-validate: reject non-2D native Geometry objects before any C allocation.
+        cdef int _i_pre
+        for _i_pre in range(n):
+            _obj_pre = geoms[_i_pre]
+            if isinstance(_obj_pre, Geometry):
+                if (<Geometry>_obj_pre).geom != NULL and tg_geom_dims(
+                        (<Geometry>_obj_pre).geom
+                ) > 2:
+                    raise ValueError(
+                        f"only 2D geometries are supported for unary_union "
+                        f"(geometry {_i_pre} has {tg_geom_dims((<Geometry>_obj_pre).geom)} dims)"
+                    )
         if (<size_t>(<unsigned int>n)) > ((<size_t>-1) // sizeof(tg_geom *)):
             raise OverflowError("geoms is too large")
         cdef const tg_geom **arr = <const tg_geom **>malloc(
@@ -1452,6 +1472,10 @@ cdef class Geometry:
         tg_geom_free(gptr)
         if g_tg == NULL:
             raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"unary_union: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     def buffer(self, distance: float, quad_segs: int = 16,
@@ -1511,16 +1535,15 @@ cdef class Geometry:
             raise RuntimeError(f"GEOSBuffer failed with distance {distance}")
 
         cdef tg_geom *g_tg = tg_geom_from_geos(ctx, g_buffered)
-        if g_tg == NULL:
-            GEOSGeom_destroy_r(ctx, g_buffered)
-            GEOSGeom_destroy_r(ctx, g_geos)
-            GEOS_finish_r(ctx)
-            raise RuntimeError("Failed to convert GEOS geometry to TG")
-
         GEOSGeom_destroy_r(ctx, g_buffered)
         GEOSGeom_destroy_r(ctx, g_geos)
         GEOS_finish_r(ctx)
-
+        if g_tg == NULL:
+            raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"buffer: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     def simplify(self, tolerance: float, preserve_topology: bool = True) -> Geometry:
@@ -1570,16 +1593,15 @@ cdef class Geometry:
             )
 
         cdef tg_geom *g_tg = tg_geom_from_geos(ctx, g_simplified)
-        if g_tg == NULL:
-            GEOSGeom_destroy_r(ctx, g_simplified)
-            GEOSGeom_destroy_r(ctx, g_geos)
-            GEOS_finish_r(ctx)
-            raise RuntimeError("Failed to convert GEOS geometry to TG")
-
         GEOSGeom_destroy_r(ctx, g_simplified)
         GEOSGeom_destroy_r(ctx, g_geos)
         GEOS_finish_r(ctx)
-
+        if g_tg == NULL:
+            raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"simplify: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     @property
@@ -1618,16 +1640,15 @@ cdef class Geometry:
             raise RuntimeError("GEOSGetCentroid failed")
 
         cdef tg_geom *g_tg = tg_geom_from_geos(ctx, g_centroid)
-        if g_tg == NULL:
-            GEOSGeom_destroy_r(ctx, g_centroid)
-            GEOSGeom_destroy_r(ctx, g_geos)
-            GEOS_finish_r(ctx)
-            raise RuntimeError("Failed to convert GEOS geometry to TG")
-
         GEOSGeom_destroy_r(ctx, g_centroid)
         GEOSGeom_destroy_r(ctx, g_geos)
         GEOS_finish_r(ctx)
-
+        if g_tg == NULL:
+            raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"centroid: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     @property
@@ -1676,16 +1697,15 @@ cdef class Geometry:
             raise RuntimeError("GEOSConvexHull failed")
 
         cdef tg_geom *g_tg = tg_geom_from_geos(ctx, g_hull)
-        if g_tg == NULL:
-            GEOSGeom_destroy_r(ctx, g_hull)
-            GEOSGeom_destroy_r(ctx, g_geos)
-            GEOS_finish_r(ctx)
-            raise RuntimeError("Failed to convert GEOS geometry to TG")
-
         GEOSGeom_destroy_r(ctx, g_hull)
         GEOSGeom_destroy_r(ctx, g_geos)
         GEOS_finish_r(ctx)
-
+        if g_tg == NULL:
+            raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"convex_hull: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     def intersection(self, other) -> Geometry:
@@ -1773,18 +1793,16 @@ cdef class Geometry:
             raise RuntimeError("GEOSIntersection failed")
 
         g_tg = tg_geom_from_geos(ctx, g_intersection)
-        if g_tg == NULL:
-            GEOSGeom_destroy_r(ctx, g_intersection)
-            GEOSGeom_destroy_r(ctx, g2_geos)
-            GEOSGeom_destroy_r(ctx, g1_geos)
-            GEOS_finish_r(ctx)
-            raise RuntimeError("Failed to convert GEOS geometry to TG")
-
         GEOSGeom_destroy_r(ctx, g_intersection)
         GEOSGeom_destroy_r(ctx, g2_geos)
         GEOSGeom_destroy_r(ctx, g1_geos)
         GEOS_finish_r(ctx)
-
+        if g_tg == NULL:
+            raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"intersection: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     def union(self, other) -> Geometry:
@@ -1844,18 +1862,16 @@ cdef class Geometry:
             raise RuntimeError("GEOSUnion failed")
 
         g_tg = tg_geom_from_geos(ctx, g_union)
-        if g_tg == NULL:
-            GEOSGeom_destroy_r(ctx, g_union)
-            GEOSGeom_destroy_r(ctx, g2_geos)
-            GEOSGeom_destroy_r(ctx, g1_geos)
-            GEOS_finish_r(ctx)
-            raise RuntimeError("Failed to convert GEOS geometry to TG")
-
         GEOSGeom_destroy_r(ctx, g_union)
         GEOSGeom_destroy_r(ctx, g2_geos)
         GEOSGeom_destroy_r(ctx, g1_geos)
         GEOS_finish_r(ctx)
-
+        if g_tg == NULL:
+            raise RuntimeError("Failed to convert GEOS geometry to TG")
+        if tg_geom_error(g_tg) != NULL:
+            err_msg = tg_geom_error(g_tg).decode("utf-8")
+            tg_geom_free(g_tg)
+            raise RuntimeError(f"union: TGX conversion error: {err_msg}")
         return _geometry_from_ptr(g_tg)
 
     cdef tuple _get_nearest_point_coords(self, Geometry other):
@@ -1910,7 +1926,7 @@ cdef class Geometry:
         # Extract the two coordinates directly (GEOS always returns exactly 2 points)
         cdef double x1, y1, x2, y2
         cdef int ret = GEOSCoordSeq_getXY_r(ctx, coords, 0, &x1, &y1)
-        if ret == -1:
+        if ret != 1:
             GEOSCoordSeq_destroy_r(ctx, coords)
             GEOSGeom_destroy_r(ctx, g2_geos)
             GEOSGeom_destroy_r(ctx, g1_geos)
@@ -1918,7 +1934,7 @@ cdef class Geometry:
             raise RuntimeError("Failed to get first coordinate")
 
         ret = GEOSCoordSeq_getXY_r(ctx, coords, 1, &x2, &y2)
-        if ret == -1:
+        if ret != 1:
             GEOSCoordSeq_destroy_r(ctx, coords)
             GEOSGeom_destroy_r(ctx, g2_geos)
             GEOSGeom_destroy_r(ctx, g1_geos)
@@ -4252,9 +4268,10 @@ cdef Geometry _transform_recursive(object func, Geometry geom):
             result = func(pts[i].x, pts[i].y)
             x_new, y_new = _validate_transform_result(result)
             transformed_coords.append((x_new, y_new))
-        return _geometry_from_ptr(tg_geom_new_linestring(
-            (<Line>Line(transformed_coords))._get_c_line())
-        )
+        # Keep an explicit reference so the Line (and its C pointer) stays alive
+        # until tg_geom_new_linestring has consumed the data.
+        tmp_transformed_line = Line(transformed_coords)
+        return _geometry_from_ptr(tg_geom_new_linestring(tmp_transformed_line._get_c_line()))
 
     # Polygon (type 3)
     elif geom_type == 3:


### PR DESCRIPTION
## Fix native-layer stability: prevent segfaults in GEOS overlay operations

### Problem

The area-slicer integration with `togo` exhibited context-dependent segfaults in
`unary_union`/`intersection`/`union` operation chains. Investigation identified five
root causes in the Cython/native layer — none of which produced a Python traceback
before crashing the process.

### Root causes & fixes

#### 1. Missing `tg_geom_error` check after `tg_geom_from_geos` (critical — most likely crash source)

`tg_geom_from_geos` (TGX bridge) can return a **non-NULL pointer carrying an error
marker** for geometry types it cannot fully represent. All seven GEOS overlay methods
(`buffer`, `simplify`, `centroid`, `convex_hull`, `intersection`, `union`,
`unary_union`) were using the result unconditionally, leading to undefined behaviour
in subsequent operations. Each conversion site now checks `tg_geom_error(g_tg)`
after the NULL guard, frees the pointer, and raises `RuntimeError` if an error is
present. The same guard was added for `tg_geom_to/from_meters_grid`. As a secondary
improvement the duplicated GEOS cleanup blocks were collapsed into a single
unconditional cleanup before both checks.

#### 2. Wrong `GEOSCoordSeq_getXY_r` return-value check

GEOS returns **1 on success, 0 on failure** — never `-1`. The old check
`if ret == -1` never fired, silently propagating uninitialised doubles into
`nearest_points` / `shortest_line` results on allocation failure.
Fixed to `if ret != 1`.

#### 3. No 2D dimensionality guard in `unary_union`

`_ensure_overlay_safe` already rejected 3D inputs in `intersection`/`union`, but
`unary_union` had no equivalent check. A pre-validation loop now raises
`ValueError` for any `Geometry` argument with `dims > 2` before any C allocation.

#### 4. Anonymous temporary `Line` lifetime in `_transform_recursive`

The `LineString` transform path used an anonymous `Line(coords)` temporary whose
reference count could theoretically reach zero before `tg_geom_new_linestring`
consumed the pointer. The temporary is now bound to an explicit named variable.

### Tests

`tests/test_stability_fixes.py` — 30 new regression tests across six classes:

| Class | Coverage |
|---|---|
| `TestOverlayReturnSanity` | All 7 overlay ops return valid, accessible results |
| `TestUnaryUnion2DGuard` | 3D input rejection in `unary_union` |
| `TestNearestPointsCoordExtraction` | Correct coordinates from `nearest_points` / `shortest_line` |
| `TestTransformLineStringLifetime` | `transform()` across all geometry types |
| `TestMetersGridErrorPropagation` | `to/from_meters_grid` round-trips incl. empty geometry |
| `TestOperationChainSafety` | Multi-step workflow: `unary_union → intersection → buffer` |

All 597 tests pass (567 pre-existing + 30 new).