### PR TITLE
Improve Shapely compatibility

### DIFF
--- a/tests/test_shapely_compat.py
+++ b/tests/test_shapely_compat.py
@@ -11,6 +11,7 @@ Covers:
 8. MultiPolygon and MultiLineString are real Python classes
 9. Geometry equality behaves consistently
 10. Difference set-operations are available in method and module forms
+11. Wrapper forwarding and Geometry protocol parity regressions
 """
 
 import pytest
@@ -550,3 +551,62 @@ class TestGeometryEquality:
         g2 = Geometry("POINT(1 2)", fmt="wkt")
         s = {g1, g2}
         assert len(s) == 1  # same geometry, should deduplicate
+
+
+# ---------------------------------------------------------------------------
+# 11. Wrapper forwarding and Geometry protocol parity regressions
+# ---------------------------------------------------------------------------
+
+
+class TestWrapperAndProtocolParity:
+    def test_polygon_wrapper_forwards_difference_equals_covers(self):
+        left = Polygon([(0, 0), (3, 0), (3, 3), (0, 3), (0, 0)])
+        right = Polygon([(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)])
+
+        diff = left.difference(right)
+        assert diff.geom_type in {"Polygon", "MultiPolygon"}
+        assert left.equals(left) is True
+        assert left.covers(Point(1, 1)) is True
+
+    def test_geometry_project_available_on_geometry_linestring(self):
+        line_geom = Geometry("LINESTRING(0 0, 10 0)", fmt="wkt")
+
+        distance = line_geom.project(Point(3, 4))
+        normalized = line_geom.project(Point(3, 4), normalized=True)
+
+        assert distance == pytest.approx(3.0, rel=1e-9)
+        assert normalized == pytest.approx(0.3, rel=1e-9)
+
+    def test_geometry_len_for_collections_and_multi(self):
+        multipoly = MultiPolygon(
+            [
+                ([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)],),
+                ([(2, 0), (3, 0), (3, 1), (2, 1), (2, 0)],),
+            ]
+        )
+
+        assert len(multipoly) == 2
+        assert len(multipoly.geoms) == 2
+
+    def test_geometry_len_raises_for_non_collections(self):
+        geom = Geometry("POINT(0 0)", fmt="wkt")
+        with pytest.raises(TypeError):
+            len(geom)
+
+    def test_from_geojson_materializes_multipolygon_class(self):
+        geom = togo.from_geojson(
+            '{"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,1],[0,0]]]]}'
+        )
+        assert isinstance(geom, MultiPolygon)
+        assert geom.geom_type == "MultiPolygon"
+
+    def test_linestring_wrapper_forwards_difference(self):
+        line = LineString([(0, 0), (5, 0)])
+        clip = Polygon([(2, -1), (3, -1), (3, 1), (2, 1), (2, -1)])
+
+        result = line.difference(clip)
+        assert result.geom_type in {
+            "LineString",
+            "MultiLineString",
+            "GeometryCollection",
+        }

--- a/togo.pyx
+++ b/togo.pyx
@@ -769,6 +769,22 @@ cdef class Geometry:
         else:
             raise IndexError("Indexing not supported for this geometry type")
 
+    def __len__(self) -> int:
+        cdef int t
+        self._ensure_initialized("this")
+        t = tg_geom_typeof(self.geom)
+        if t == 4:
+            return tg_geom_num_points(self.geom)
+        if t == 5:
+            return tg_geom_num_lines(self.geom)
+        if t == 6:
+            return tg_geom_num_polys(self.geom)
+        if t == 7:
+            return tg_geom_num_geometries(self.geom)
+        raise TypeError(
+            f"object of type '{self.__class__.__module__}.{self.__class__.__name__}' has no len()"
+        )
+
     @staticmethod
     def from_linestring(points) -> Geometry:
         """Create LineString geometry from points"""
@@ -2054,6 +2070,56 @@ cdef class Geometry:
 
         return _geometry_from_ptr_concrete(g_tg)
 
+    def project(self, point, normalized: bool = False) -> float:
+        """Return distance along a linear geometry to the nearest point projection."""
+        cdef GEOSContextHandle_t ctx
+        cdef GEOSGeometry *g_line
+        cdef GEOSGeometry *g_point
+        cdef double result
+        cdef Geometry point_geom
+        cdef double total_len
+        cdef int t
+
+        self._ensure_initialized("this")
+        t = tg_geom_typeof(self.geom)
+        if t not in (2, 5):
+            raise TypeError(
+                "project() is only defined for LineString and MultiLineString geometries"
+            )
+
+        point_geom = _coerce_geometry_or_raise(point, "point")
+
+        ctx = GEOS_init_r()
+        if ctx == NULL:
+            raise RuntimeError("Failed to initialize GEOS context")
+
+        g_line = tg_geom_to_geos(ctx, self.geom)
+        if g_line == NULL:
+            GEOS_finish_r(ctx)
+            raise RuntimeError("Failed to convert line geometry to GEOS")
+
+        g_point = tg_geom_to_geos(ctx, point_geom._get_c_geom())
+        if g_point == NULL:
+            GEOSGeom_destroy_r(ctx, g_line)
+            GEOS_finish_r(ctx)
+            raise RuntimeError("Failed to convert point geometry to GEOS")
+
+        result = GEOSProject_r(ctx, g_line, g_point)
+        GEOSGeom_destroy_r(ctx, g_point)
+        GEOSGeom_destroy_r(ctx, g_line)
+        GEOS_finish_r(ctx)
+
+        if result < 0:
+            raise RuntimeError("GEOSProject failed")
+
+        if normalized:
+            total_len = self.length
+            if total_len <= 0.0:
+                return 0.0
+            return max(0.0, min(1.0, result / total_len))
+
+        return result
+
     cdef tuple _get_nearest_point_coords(self, Geometry other):
         """
         Private helper method to extract nearest point coordinates using GEOS.
@@ -2265,6 +2331,10 @@ cdef class Point:
 
     def __reduce__(self):
         return (Point, (self.pt.x, self.pt.y))
+
+    def __getattr__(self, name):
+        # Delegate missing Shapely-style methods/properties to the Geometry view.
+        return getattr(self.as_geometry(), name)
 
     @property
     def x(self) -> float:
@@ -2668,6 +2738,10 @@ cdef class Ring:
     def __reduce__(self):
         return (Ring, (self.points(as_tuples=True),))
 
+    def __getattr__(self, name):
+        # Delegate missing Shapely-style methods/properties to the Geometry view.
+        return getattr(self.as_geometry(), name)
+
     @staticmethod
     cdef Ring from_ptr(tg_ring *ptr):
         if ptr == NULL:
@@ -3015,6 +3089,10 @@ cdef class Line:
 
     def __reduce__(self):
         return (Line, (self.points(as_tuples=True),))
+
+    def __getattr__(self, name):
+        # Delegate missing Shapely-style methods/properties to the Geometry view.
+        return getattr(self.as_geometry(), name)
 
     @property
     def num_points(self) -> int:
@@ -3451,6 +3529,10 @@ cdef class Poly:
                 [self.hole(i).points(as_tuples=True) for i in range(self.num_holes())],
             ),
         )
+
+    def __getattr__(self, name):
+        # Delegate missing Shapely-style methods/properties to the Geometry view.
+        return getattr(self.as_geometry(), name)
 
     @property
     def exterior(self) -> Ring:
@@ -4107,12 +4189,12 @@ def box(minx, miny, maxx, maxy, ccw=True) -> Polygon:
 # Shapely-compatible module-level functions
 def from_wkt(wkt_string: str) -> Geometry:
     """Create a Geometry from a WKT string (Shapely-compatible)"""
-    return Geometry(wkt_string, fmt="wkt")
+    return _materialize_concrete_geometry(Geometry(wkt_string, fmt="wkt"))
 
 
 def from_geojson(geojson_string: str) -> Geometry:
     """Create a Geometry from a GeoJSON string (Shapely-compatible)"""
-    return Geometry(geojson_string, fmt="geojson")
+    return _materialize_concrete_geometry(Geometry(geojson_string, fmt="geojson"))
 
 
 def from_wkb(wkb_bytes: bytes) -> Geometry:
@@ -4137,7 +4219,7 @@ def from_wkb(wkb_bytes: bytes) -> Geometry:
         tg_geom_free(g)
         raise ValueError(err.decode("utf-8"))
 
-    return _geometry_from_ptr(g)
+    return _geometry_from_ptr_concrete(g)
 
 
 def to_wkt(geom) -> str:


### PR DESCRIPTION
## Title
Improve Shapely compatibility: method forwarding, Geometry protocol parity, and concrete type materialization

## Why
After removing consumer-side compatibility shims, downstream MBP tests exposed remaining Shapely parity gaps in ToGo, primarily around:

- missing wrapper method surface (`difference`, `equals`, `covers`)
- missing `project(...)` on line-like `Geometry` results
- missing collection protocol behavior (`len(...)` on multi/collection geometries)
- inconsistent concrete return materialization from parsing helpers (`from_geojson`, etc.)

This MR closes those gaps to improve drop-in behavior.

## What Changed

### 1) `Geometry` protocol parity (`togo.pyx`)
- Added `Geometry.__len__` for:
  - `MultiPoint`
  - `MultiLineString`
  - `MultiPolygon`
  - `GeometryCollection`
- Non-collection geometries now raise Shapely-like `TypeError` for `len(...)`.
- Added `Geometry.project(point, normalized=False)` for line-like `Geometry`:
  - supports `LineString`/`MultiLineString`
  - supports `normalized=True`
  - uses GEOS projection path and normalized length behavior

### 2) Wrapper forwarding for Shapely-style ergonomics (`togo.pyx`)
Added `__getattr__` delegation to underlying `as_geometry()` for:
- `Point`
- `Ring`
- `Line`
- `Poly`

This ensures operation/predicate access on wrappers is consistent with Shapely usage patterns (including downstream code that expects direct methods).

### 3) Concrete materialization on parse helpers (`togo.pyx`)
Updated parser helpers to materialize concrete geometry classes where determinable:
- `from_wkt(...)`
- `from_geojson(...)`
- `from_wkb(...)`

This avoids unnecessary generic `Geometry` returns for concrete multi types (e.g. `MultiPolygon`).

### 4) Test consolidation and expanded parity coverage
- Merged the standalone regression file into `tests/test_shapely_compat.py`.
- Added a dedicated section:
  - wrapper forwarding regression tests
  - `Geometry.project` on line-like `Geometry`
  - `__len__` behavior for collection vs non-collection geometries
  - concrete materialization check for `from_geojson(...)`
- Removed duplicate standalone regression test file after merge.

## Validation

Executed:

```bash
make build-wheel
.venv/bin/pytest tests/test_shapely_compat.py -q