### PR TITLE
Improve Shapely compatibility.

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -166,6 +166,11 @@ len(multi)        # size of the corresponding Multi*
 
 ```python
 geom = shape({"type": "Point", "coordinates": [1, 2]})
+type(geom).__name__  # 'Point'
+
+poly = shape({"type": "Polygon", "coordinates": [[(0, 0), (1, 0), (1, 1), (0, 0)]]})
+type(poly).__name__  # 'Polygon'
+
 rect = box(0, 0, 10, 5)
 ```
 
@@ -185,6 +190,10 @@ geom.__geo_interface__  # Dict: GeoJSON-like
 # Point Geometry results expose x/y (e.g., centroid outputs)
 center = Polygon([(0, 0), (4, 0), (4, 4), (0, 4), (0, 0)]).centroid
 center.x, center.y
+
+# Line boundary endpoints are exposed as Point-like values
+endpoints = LineString([(1, 2), (5, 2), (8, 9)]).boundary.geoms
+endpoints[0].x, endpoints[0].y
 ```
 
 ## Geometric Operations

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install togo
 - Advanced operations via libgeos integration (buffer, unary union, union/difference, simplify, centroid, convex_hull, etc.)
 - Distance and proximity operations (nearest_points, shortest_line, project)
 - `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` are real Python classes — `isinstance()` checks work correctly
-- `BaseGeometry` alias is available for Shapely-style base-type checks
+- `BaseGeometry` is available for Shapely-style base-type checks across concrete ToGo geometry classes
 - Geometry equality via `==` operator consistent with Shapely semantics
 - Overlay/unary union operations accept 3D input and normalize topology to 2D
 
@@ -95,9 +95,14 @@ bbox = Polygon.from_bounds(0, 0, 10, 5)
 print(bbox.area)           # 50.0
 
 # Centroid (Shapely-compatible)
-centroid = poly.centroid  # Returns a Point geometry
+centroid = poly.centroid  # Returns a concrete Point for non-empty geometries
 print(centroid.to_wkt())  # e.g., 'POINT (2 2)'
 print(centroid.x, centroid.y)  # 2.0 2.0
+
+# Line boundaries expose point-like endpoints via .geoms
+line = LineString([(1, 2), (5, 2), (8, 9)])
+endpoints = line.boundary.geoms
+print(endpoints[0].x, endpoints[0].y)  # 1.0 2.0
 
 # Convex hull (Shapely-compatible)
 from togo import convex_hull
@@ -115,13 +120,14 @@ from togo import shape, box
 g1 = shape({"type": "Point", "coordinates": [1, 2]})
 g2 = box(0, 0, 2, 1)
 print(g1.geom_type, g2.geom_type)
+print(type(g1).__name__, type(g2).__name__)  # Point Polygon
 ```
 
 You can also call module-level helpers with `from togo import union, difference` and then
 `union(poly, other)` or `difference(poly, other)`.
 
-For compatibility with Shapely-style base checks, `BaseGeometry` is exported as an alias of
-`Geometry`:
+For compatibility with Shapely-style base checks, `BaseGeometry` supports `isinstance(...)`
+across concrete public geometry classes:
 
 ```python
 from togo import BaseGeometry, MultiPolygon, unary_union, from_wkt

--- a/SHAPELY_API.md
+++ b/SHAPELY_API.md
@@ -39,16 +39,21 @@ ToGo provides the following Shapely-compatible class names:
 - `MultiLineString` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
 - `MultiPolygon` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
 - `GeometryCollection` - **Real Python class** inheriting from `Geometry`; `isinstance()` checks work
-- `BaseGeometry` - alias for `Geometry` for Shapely-style base-type checks
+- `BaseGeometry` - Shapely-style base-type check target for concrete ToGo geometry classes (`Geometry`, `Point`, `LineString`, `Polygon`, `Multi*`, `GeometryCollection`)
 
 ```python
-from togo import BaseGeometry, MultiPolygon, MultiLineString, Geometry, Poly, Ring
+from togo import BaseGeometry, MultiPolygon, MultiLineString, Geometry, Point, Polygon, Poly, Ring
 
 poly1 = Poly(Ring([(0,0), (1,0), (1,1), (0,1), (0,0)]))
 mp = MultiPolygon([poly1])
 print(isinstance(mp, MultiPolygon))  # True
 print(isinstance(mp, Geometry))      # True
 print(isinstance(mp, BaseGeometry))  # True
+
+pt = Point(1, 2)
+poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 0)])
+print(isinstance(pt, BaseGeometry))    # True
+print(isinstance(poly, BaseGeometry))  # True
 
 mls = MultiLineString([[(0,0), (1,1)]])
 print(isinstance(mls, MultiLineString))  # True
@@ -137,7 +142,7 @@ poly_with_hole = Polygon(exterior, holes=[hole])
 print(poly.geom_type)         # 'Polygon'
 print(poly.bounds)            # (0, 0, 4, 4)
 print(poly.area)              # 16.0
-print(poly.centroid)          # Point geometry (center of mass)
+print(poly.centroid)          # Point geometry (center of mass; concrete Point when non-empty)
 print(poly.is_empty)          # False
 print(poly.is_valid)          # True
 print(poly.exterior)          # Ring object (exterior ring)
@@ -181,7 +186,14 @@ wkb_bytes = bytes.fromhex("0101000000000000000000F03F0000000000000040")
 wkb_geom = from_wkb(wkb_bytes)
 print(wkb_geom.geom_type)
 
-# Parsing helpers materialize concrete multi classes when determinable
+# Parsing helpers materialize concrete classes when determinable
+pt = from_geojson('{"type":"Point","coordinates":[1,2]}')
+print(type(pt).__name__)  # Point
+
+poly = from_geojson('{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}')
+print(type(poly).__name__)  # Geometry (use shape() for concrete Polygon materialization)
+
+# Multi geometries are materialized directly
 mp = from_geojson('{"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,1],[0,0]]]]}')
 print(type(mp).__name__)  # MultiPolygon
 ```
@@ -194,6 +206,10 @@ from togo import shape, box
 # shape() from GeoJSON-like mapping or __geo_interface__ object
 geom = shape({"type": "Point", "coordinates": [1, 2]})
 print(geom.geom_type)  # 'Point'
+print(type(geom).__name__)  # Point
+
+poly = shape({"type": "Polygon", "coordinates": [[(0, 0), (1, 0), (1, 1), (0, 0)]]})
+print(type(poly).__name__)  # Polygon
 
 # box() from bounds
 rect = box(0, 0, 3, 2)
@@ -322,6 +338,11 @@ print(poly.interiors)        # List[Ring]: list of holes
 print(poly.centroid)         # Point: center of mass
 print(poly.boundary)         # LineString: exterior ring as a line
 print(poly_with_hole.boundary)  # MultiLineString: exterior + interior rings
+
+line = LineString([(1, 2), (5, 2), (8, 9)])
+endpoints = line.boundary.geoms
+print(type(endpoints[0]).__name__)  # Point
+print(endpoints[0].x, endpoints[0].y)  # 1.0 2.0
 ```
 
 For multi-geometries and geometry collections, use `.geoms` to access members as a tuple.

--- a/tests/test_shapely_compat.py
+++ b/tests/test_shapely_compat.py
@@ -18,6 +18,7 @@ import pytest
 
 import togo
 from togo import (
+    BaseGeometry,
     Geometry,
     Line,
     LineString,
@@ -27,6 +28,7 @@ from togo import (
     Poly,
     Polygon,
     Ring,
+    shape,
     unary_union,
 )
 
@@ -610,3 +612,54 @@ class TestWrapperAndProtocolParity:
             "MultiLineString",
             "GeometryCollection",
         }
+
+    def test_base_geometry_isinstance_for_single_geometries(self):
+        point = Point(0, 0)
+        polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 0)])
+
+        assert isinstance(point, BaseGeometry)
+        assert isinstance(polygon, BaseGeometry)
+
+    def test_shape_materializes_polygon_and_multipolygon_concrete_types(self):
+        polygon = shape(
+            {
+                "type": "Polygon",
+                "coordinates": [[(0, 0), (1, 0), (1, 1), (0, 0)]],
+            }
+        )
+        multipolygon = shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [[(0, 0), (1, 0), (1, 1), (0, 0)]],
+                    [[(2, 2), (3, 2), (3, 3), (2, 2)]],
+                ],
+            }
+        )
+
+        assert isinstance(polygon, Polygon)
+        assert isinstance(multipolygon, MultiPolygon)
+        assert isinstance(multipolygon, BaseGeometry)
+
+    def test_centroid_materializes_point_with_xy_accessors(self):
+        geom = shape(
+            {
+                "type": "Polygon",
+                "coordinates": [[(0, 0), (1, 0), (1, 1), (0, 0)]],
+            }
+        )
+
+        centroid = geom.centroid
+
+        assert isinstance(centroid, Point)
+        assert hasattr(centroid, "x") and hasattr(centroid, "y")
+
+    def test_line_boundary_geoms_materialize_points(self):
+        line = LineString([(1, 2), (5, 2), (8, 9)])
+        endpoints = line.boundary.geoms
+
+        assert len(endpoints) == 2
+        assert isinstance(endpoints[0], Point)
+        assert isinstance(endpoints[1], Point)
+        assert (endpoints[0].x, endpoints[0].y) == (1.0, 2.0)
+        assert (endpoints[1].x, endpoints[1].y) == (8.0, 9.0)

--- a/togo.pyx
+++ b/togo.pyx
@@ -305,6 +305,25 @@ cdef object _geometry_from_ptr_concrete(tg_geom *ptr):
     return _materialize_concrete_geometry(_geometry_from_ptr(ptr))
 
 
+def _shape_materialize_concrete(Geometry geom):
+    """Materialize shape()/GeoJSON results to concrete public classes where deterministic."""
+    cdef int t
+    if geom is None or geom.geom == NULL:
+        return geom
+
+    t = tg_geom_typeof(geom.geom)
+    if t == 1:
+        return Point(geom.x, geom.y)
+    if t == 2:
+        return Line(geom.coords)
+    if t == 3:
+        return Polygon(
+            geom.exterior.points(as_tuples=True),
+            [ring.points(as_tuples=True) for ring in geom.interiors],
+        )
+    return _materialize_concrete_geometry(geom)
+
+
 cdef Line _line_from_ptr(tg_line *ptr):
     if ptr == NULL:
         raise ValueError("Received NULL LineString pointer")
@@ -1034,7 +1053,7 @@ cdef class Geometry:
             n = tg_geom_num_points(self.geom)
             for i in range(n):
                 pt = tg_geom_point_at(self.geom, i)
-                result.append(_geometry_from_ptr_concrete(tg_geom_new_point(pt)))
+                result.append(Point(pt.x, pt.y))
             return tuple(result)
         if t == 5:
             n = tg_geom_num_lines(self.geom)
@@ -1703,7 +1722,7 @@ cdef class Geometry:
         return _geometry_from_ptr_concrete(g_tg)
 
     @property
-    def centroid(self) -> Geometry:
+    def centroid(self):
         """
         Return the centroid of the geometry.
 
@@ -1747,7 +1766,10 @@ cdef class Geometry:
             err_msg = tg_geom_error(g_tg).decode("utf-8")
             tg_geom_free(g_tg)
             raise RuntimeError(f"centroid: TGX conversion error: {err_msg}")
-        return _geometry_from_ptr_concrete(g_tg)
+        cdef Geometry centroid_geom = _geometry_from_ptr(g_tg)
+        if tg_geom_typeof(centroid_geom.geom) == 1 and tg_geom_is_empty(centroid_geom.geom) == 0:
+            return Point(centroid_geom.x, centroid_geom.y)
+        return _materialize_concrete_geometry(centroid_geom)
 
     @property
     def convex_hull(self) -> Geometry:
@@ -2510,7 +2532,7 @@ cdef class Point:
         raise ValueError(f"other must be a Geometry object, got {type(other)}")
 
     @property
-    def centroid(self) -> Geometry:
+    def centroid(self):
         """
         Return the centroid of the point (which is the point itself).
 
@@ -2947,7 +2969,7 @@ cdef class Ring:
             raise ValueError(f"other must be a Geometry object, got {type(other)}")
 
     @property
-    def centroid(self) -> Geometry:
+    def centroid(self):
         """
         Return the centroid of the ring.
 
@@ -3304,7 +3326,7 @@ cdef class Line:
             raise ValueError(f"other must be a Geometry object, got {type(other)}")
 
     @property
-    def centroid(self) -> Geometry:
+    def centroid(self):
         """
         Return the centroid of the linestring.
 
@@ -3773,7 +3795,7 @@ cdef class Poly:
             raise ValueError(f"other must be a Geometry object, got {type(other)}")
 
     @property
-    def centroid(self) -> Geometry:
+    def centroid(self):
         """
         Return the centroid of the polygon.
 
@@ -3973,7 +3995,6 @@ def set_polygon_indexing_mode(ix: TGIndex) -> None:
 
 # Shapely-compatible aliases
 LineString = Line
-BaseGeometry = Geometry
 
 
 class Polygon(Poly):
@@ -4111,6 +4132,19 @@ class GeometryCollection(Geometry):
         return f"GeometryCollection({self.to_wkt()})"
 
 
+# Keep isinstance(BaseGeometry, ...) compatibility across all concrete public classes.
+BaseGeometry = (
+    Geometry,
+    Point,
+    Line,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryCollection,
+)
+
+
 def unary_union(geoms) -> Geometry:
     """Return the unary union of a sequence of geometries using GEOS (Shapely-compatible).
 
@@ -4134,7 +4168,7 @@ def unary_union(geoms) -> Geometry:
     return Geometry.unary_union(list(geoms))
 
 
-def shape(obj) -> Geometry:
+def shape(obj):
     """Create a Geometry from a GeoJSON-like mapping or JSON text.
 
     Accepts all standard GeoJSON types plus ``LinearRing``, which is
@@ -4154,7 +4188,7 @@ def shape(obj) -> Geometry:
         obj = obj.decode("utf-8")
 
     if isinstance(obj, str):
-        return from_geojson(obj)
+        return _shape_materialize_concrete(from_geojson(obj))
 
     if isinstance(obj, dict):
         # TG's GeoJSON parser does not recognise "LinearRing".  Normalise it
@@ -4168,7 +4202,7 @@ def shape(obj) -> Geometry:
             if not coords:
                 coords = []
             return Ring(coords).as_geometry()
-        return from_geojson(json.dumps(obj))
+        return _shape_materialize_concrete(from_geojson(json.dumps(obj)))
 
     raise TypeError("shape() requires a GeoJSON mapping/string or __geo_interface__ object")
 


### PR DESCRIPTION
## What this MR does

This MR improves Shapely compatibility parity in ToGo so MBP can rely on ToGo objects directly without compatibility fallbacks.

## Why

MBP was hitting type/parity issues such as:
- `ValueError: can't load a shape from a <class 'togo.Polygon'>`
- unexpected `isinstance(..., togo.Polygon)` failures after GeoJSON `shape(...)`
- centroid/boundary delegated checks receiving non-concrete or non-point-like values

## Changes

### Core behavior fixes (`togo.pyx`)
- `shape(...)` now materializes deterministic concrete classes where representable:
  - Point -> `togo.Point`
  - LineString -> `togo.Line` / `LineString`
  - Polygon -> `togo.Polygon`
  - Multi* / collections keep concrete materialization behavior
- `Geometry.centroid` now returns concrete `Point` for non-empty point centroids.
- Empty centroid edge-case fixed: avoids accessing `.x/.y` on empty points.
- `Geometry.geoms` for multipoints now yields concrete `Point` instances (supports `.x/.y` endpoint access).
- `BaseGeometry` now supports reliable `isinstance(obj, BaseGeometry)` checks across public concrete geometry classes.

### Tests
- Moved MBP parity tests into existing Shapely compatibility suite:
  - `tests/test_shapely_compat.py` (`TestWrapperAndProtocolParity`)
- Added coverage for:
  - `BaseGeometry` isinstance parity on concrete instances
  - `shape(...)` concrete materialization (`Polygon`, `MultiPolygon`)
  - centroid concrete point materialization with `.x/.y`
  - line boundary endpoints as concrete point-like objects via `.boundary.geoms`

### Documentation
Updated:
- `README.md`
- `SHAPELY_API.md`
- `QUICK_REFERENCE.md`

Docs now reflect:
- concrete materialization behavior (`shape`, centroid, boundary endpoints)
- current `BaseGeometry` parity semantics

## Validation

- Focused compatibility/parity tests were run during implementation and passed.
- Full suite status: **all tests pass** (per final run).

## MBP impact

This unblocks removal of MBP compatibility fallbacks in:
- `mbp/areas.py` (`GEOMETRY_TYPES`/`is_geometry(...)` acceptance fallback, `_from_geojson_geometry(...)`)
- `mbp/areas.py::EarthArea.__getattr__` centroid/exterior coercions
- related type/shape acceptance logic in `mbp/geometry.py`