### PR TITLE
Improve Shapely compatibility

### DIFF
--- a/tests/test_multiprocessing_serialization.py
+++ b/tests/test_multiprocessing_serialization.py
@@ -237,7 +237,7 @@ class TestSubGeometryPickleRoundtrip:
         poly = Polygon.from_bounds(0, 0, 1, 1)
         ring = poly.exterior
 
-        assert type(pickle.loads(pickle.dumps(ring))) is Ring
+        assert type(pickle.loads(pickle.dumps(ring))) is type(ring)
         assert type(pickle.loads(pickle.dumps(poly))) is Polygon
 
     def test_repeated_roundtrip_stable(self):

--- a/tests/test_shapely_compat.py
+++ b/tests/test_shapely_compat.py
@@ -595,6 +595,30 @@ class TestWrapperAndProtocolParity:
         with pytest.raises(TypeError):
             len(geom)
 
+    def test_geometry_truthiness_uses_emptiness_not_len(self):
+        non_empty = Geometry("LINESTRING(0 0, 1 1)", fmt="wkt")
+        empty = Geometry("GEOMETRYCOLLECTION EMPTY", fmt="wkt")
+
+        assert bool(non_empty) is True
+        assert bool(empty) is False
+
+    def test_singleton_geoms_available_for_single_part_results(self):
+        line = LineString([(0, 0), (2, 0)])
+        clip = Polygon([(1, -1), (3, -1), (3, 1), (1, 1), (1, -1)])
+
+        result = line.intersection(clip)
+
+        assert result.geom_type == "LineString"
+        assert isinstance(result.geoms, tuple)
+        assert len(result.geoms) == 1
+        assert result.geoms[0].geom_type == "LineString"
+
+    def test_polygon_exterior_is_linestring_compatible(self):
+        polygon = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+
+        assert isinstance(polygon.exterior, LineString)
+        assert polygon.exterior.coords[0] == (0.0, 0.0)
+
     def test_from_geojson_materializes_multipolygon_class(self):
         geom = togo.from_geojson(
             '{"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,1],[0,0]]]]}'

--- a/togo.pyx
+++ b/togo.pyx
@@ -804,6 +804,11 @@ cdef class Geometry:
             f"object of type '{self.__class__.__module__}.{self.__class__.__name__}' has no len()"
         )
 
+    def __bool__(self) -> bool:
+        """Shapely-compatible truthiness: empty geometries are falsey."""
+        self._ensure_initialized("this")
+        return tg_geom_is_empty(self.geom) == 0
+
     @staticmethod
     def from_linestring(points) -> Geometry:
         """Create LineString geometry from points"""
@@ -1074,6 +1079,9 @@ cdef class Geometry:
                 if g != NULL:
                     result.append(_geometry_from_ptr_concrete(tg_geom_clone(g)))
             return tuple(result)
+        if t in (1, 2, 3):
+            # Tolerate collection-style access for singleton geometries in Shapely-compat flows.
+            return (self,)
         raise AttributeError(f"geoms not available for {self.type_string()}")
 
     @property
@@ -2351,6 +2359,9 @@ cdef class Point:
     def __hash__(self):
         return hash((self.pt.x, self.pt.y))
 
+    def __bool__(self) -> bool:
+        return True
+
     def __reduce__(self):
         return (Point, (self.pt.x, self.pt.y))
 
@@ -2757,6 +2768,9 @@ cdef class Ring:
     def __hash__(self):
         return hash(self.as_geometry().to_wkb())
 
+    def __bool__(self) -> bool:
+        return not self.is_empty
+
     def __reduce__(self):
         return (Ring, (self.points(as_tuples=True),))
 
@@ -3108,6 +3122,9 @@ cdef class Line:
 
     def __hash__(self):
         return hash(self.as_geometry().to_wkb())
+
+    def __bool__(self) -> bool:
+        return not self.is_empty
 
     def __reduce__(self):
         return (Line, (self.points(as_tuples=True),))
@@ -3541,6 +3558,9 @@ cdef class Poly:
 
     def __hash__(self):
         return hash(self.as_geometry().to_wkb())
+
+    def __bool__(self) -> bool:
+        return not self.is_empty
 
     def __reduce__(self):
         return (
@@ -3997,6 +4017,27 @@ def set_polygon_indexing_mode(ix: TGIndex) -> None:
 LineString = Line
 
 
+class LinearRing(Line):
+    """Shapely-compatible LinearRing that remains LineString-compatible."""
+
+    def __init__(self, points):
+        points = list(points)
+        if points and points[0] != points[-1]:
+            points.append(points[0])
+        super().__init__(points)
+
+    @property
+    def geom_type(self) -> str:
+        return "LinearRing"
+
+    @property
+    def __geo_interface__(self) -> dict:
+        return {"type": "LinearRing", "coordinates": self.points(as_tuples=True)}
+
+    def __reduce__(self):
+        return (LinearRing, (self.points(as_tuples=True),))
+
+
 class Polygon(Poly):
     """Shapely-compatible Polygon class that extends Poly.
 
@@ -4047,6 +4088,11 @@ class Polygon(Poly):
             (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy), (minx, miny)
         ]
         return cls(coords)
+
+    @property
+    def exterior(self) -> LinearRing:
+        """Return the exterior as a LinearRing (also a LineString)."""
+        return LinearRing(super().exterior.points(as_tuples=True))
 
 
 class MultiPolygon(Geometry):
@@ -4898,7 +4944,7 @@ def convex_hull(geom):
 
 __all__ = [
     "Geometry", "BaseGeometry", "Point", "Rect", "Ring", "Line", "Poly", "Segment",
-    "LineString", "Polygon",
+    "LineString", "LinearRing", "Polygon",
     "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection",
     "from_wkt", "from_geojson", "from_wkb",
     "to_wkt", "to_geojson", "to_wkb",


### PR DESCRIPTION
# MR: Improve Shapely Compatibility for MBP Integration

## Why
This MR addresses Shapely-compatibility gaps observed when running MBP (Model Based Planner) with ToGo as the geometry backend.

The key issues were:
- Boolean checks on geometry objects could raise (`TypeError: ... has no len()`) instead of behaving by emptiness semantics.
- `.geoms` access on single-part geometry values raised `AttributeError` in mixed-result paths.
- `Polygon.exterior` compatibility needed to satisfy both:
  - `isinstance(..., LineString)` expectations in MBP call sites/tests.
  - `LinearRing` GeoInterface/pickling expectations from existing ToGo serialization tests.

## What Changed

### 1) Boolean protocol compatibility
Updated geometry truthiness so objects are safely usable in `if geom:` / `if not geom:` paths.

- Added `__bool__` on `Geometry` based on emptiness semantics.
- Added `__bool__` to wrapper classes for consistency:
  - `Point`
  - `Ring`
  - `Line`
  - `Poly`

## 2) `.geoms` compatibility for singleton geometries
Extended `Geometry.geoms` behavior:
- Existing behavior for `Multi*` and `GeometryCollection` is unchanged.
- For single-part geometry types (`Point`, `LineString`, `Polygon`), `.geoms` now returns a singleton tuple `(self,)`.

This keeps collection-style iteration robust in downstream paths that may receive either single or multi results.

### 3) Exterior ring type compatibility
Introduced a dedicated `LinearRing` class:
- `LinearRing` subclasses `Line` (therefore remains `LineString`-compatible for `isinstance`).
- `LinearRing.__geo_interface__` returns `{"type": "LinearRing", ...}`.
- `LinearRing.__reduce__` preserves `LinearRing` type on pickle roundtrip.

Updated `Polygon.exterior` to return `LinearRing`.

Export changes:
- Added `LinearRing` to module `__all__`.

### 4) Regression tests
Added/updated tests to cover the compatibility contract:
- Truthiness semantics based on emptiness.
- Singleton `.geoms` access for single-part intersection outputs.
- `Polygon.exterior` LineString compatibility.
- Pickle type-preservation assertion aligned with exterior return type contract.

## Files Updated
- `togo.pyx`
- `tests/test_shapely_compat.py`
- `tests/test_multiprocessing_serialization.py`

## Validation
Full test suite run:
- `640 passed`

## Impact
This change improves ToGo behavior in Shapely-style usage patterns used by MBP while preserving existing serialization and GeoInterface compatibility expectations.

## Risk / Notes
- `.geoms` is now permissive on singleton geometries; this is intentional for compatibility and may differ from strict behavior expected in some code paths.
- `Polygon.exterior` now returns `LinearRing` (a `Line` subclass), preserving both `LineString`-compat and `LinearRing` identity where required.

